### PR TITLE
Use Depot for Docker builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -32,13 +33,8 @@ jobs:
         run: |
           make frontend-build-${{ github.ref_name == 'sandbox' && 'sandbox' || 'prod' }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          image: 'tonistiigi/binfmt:latest'
-          platforms: 'amd64,arm64'
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+      - name: Set up Depot
+        uses: depot/setup-action@v1
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
@@ -63,8 +59,9 @@ jobs:
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: depot/build-push-action@v1
         with:
+          project: abc123xyz
           platforms: linux/amd64,linux/arm64
           context: .
           file: Dockerfile
@@ -73,5 +70,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             FASTEN_ENV=${{ github.ref_name == 'sandbox' && 'sandbox' || 'prod' }}
-#          cache-from: type=gha
-#          cache-to: type=gha,mode=max


### PR DESCRIPTION
This PR uses [Depot](https://depot.dev) to build and push Docker images, for both amd64 and arm64. Depot's `depot/build-push-action` implements the same inputs as Docker's action, so switching is easy.

You'll need to create a new Depot project, and then we can add its ID below as the `project` input.

You will also need to edit that project's settings and add this repo under `Trust Relationships` - that will let Depot use GitHub's OIDC Actions token for authentication, which provides short-lived access to the Depot project and means you don't need to configure any static access tokens:

<img width="902" alt="image" src="https://user-images.githubusercontent.com/130874/215557706-df050e3f-4935-42d5-a964-229a21b9474b.png">


---

Related to #34