### PR TITLE
Add deploy to digital ocean button

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,7 +1,6 @@
 spec:
   name: fasten-onprem
   services:
-    - 
     - dockerfile_path: Dockerfile
       name: app
       git:

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,11 +1,15 @@
 spec:
   name: fasten-onprem
   services:
+    - 
     - dockerfile_path: Dockerfile
       name: app
       git:
         branch: add-deploy-to-digital-ocean-button
         repo_clone_url: https://github.com/cfu288/fasten-onprem.git
       envs:
+        - key: FASTEN_ENV
+          scope: BUILD_TIME
+          value: prod
         - key: FASTEN_ISSUER_JWT_KEY
           scope: RUN_TIME

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -4,7 +4,7 @@ spec:
     - dockerfile_path: Dockerfile
       name: app
       git:
-        branch: main
+        branch: feat/add-deploy-to-digital-ocean-button
         repo_clone_url: https://github.com/cfu288/fasten-onprem.git
       envs:
         - key: FASTEN_ISSUER_JWT_KEY

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,0 +1,11 @@
+spec:
+  name: fasten-onprem
+  services:
+    - dockerfile_path: Dockerfile
+      name: app
+      git:
+        branch: main
+        repo_clone_url: https://github.com/cfu288/fasten-onprem.git
+      envs:
+        - key: FASTEN_ISSUER_JWT_KEY
+          scope: RUN_TIME

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -4,7 +4,7 @@ spec:
     - dockerfile_path: Dockerfile
       name: app
       git:
-        branch: feat/add-deploy-to-digital-ocean-button
+        branch: add-deploy-to-digital-ocean-button
         repo_clone_url: https://github.com/cfu288/fasten-onprem.git
       envs:
         - key: FASTEN_ISSUER_JWT_KEY

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -10,5 +10,5 @@ spec:
         - key: FASTEN_ENV
           scope: BUILD_TIME
           value: prod
-        - key: FASTEN_ISSUER_JWT_KEY
+        - key: FASTEN_JWT_ISSUER_KEY
           scope: RUN_TIME

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,7 +214,7 @@ a CDN or minimal Nginx deployment.
 
 
 ### How do I change the default encryption key and admin credentials
-- FASTEN_ISSUER_JWT_KEY
+- FASTEN_JWT_ISSUER_KEY
 
 
 ### Generate JWT for local use

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ COPY --from=backend-build /go/bin/fasten /opt/fasten/fasten
 COPY LICENSE.md /opt/fasten/LICENSE.md
 COPY config.yaml /opt/fasten/config/config.yaml
 
-CMD ["/opt/fasten/fasten", "start", "--config", "/opt/fasten/config/config.yaml"]
+CMD ["/opt/fasten/fasten", "start", "--config", "/opt/fasten/config/config.yaml", "--debug"]
 
 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <a href="https://cloud.digitalocean.com/apps/new?repo=https://github.com/cfu288/fasten-onprem/tree/main">
+  <a href="https://cloud.digitalocean.com/apps/new?repo=https://github.com/cfu288/fasten-onprem/tree/feat/add-deploy-to-digital-ocean-button">
     <img src="https://www.deploytodo.com/do-btn-blue.svg" alt="Deploy to DO">
   </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
   </a>
 </p>
 
+<p align="center">
+  <a href="https://cloud.digitalocean.com/apps/new?repo=https://github.com/cfu288/fasten-onprem/tree/main">
+    <img src="https://www.deploytodo.com/do-btn-blue.svg" alt="Deploy to DO">
+  </a>
+</p>
+
 # Fasten - On Premise/Self-Hosted
 
 [![CI](https://github.com/fastenhealth/fasten-onprem/actions/workflows/ci.yaml/badge.svg)](https://github.com/fastenhealth/fasten-onprem/actions/workflows/ci.yaml)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <a href="https://cloud.digitalocean.com/apps/new?repo=https://github.com/cfu288/fasten-onprem/tree/feat/add-deploy-to-digital-ocean-button">
+  <a href="https://cloud.digitalocean.com/apps/new?repo=https://github.com/cfu288/fasten-onprem/tree/add-deploy-to-digital-ocean-button">
     <img src="https://www.deploytodo.com/do-btn-blue.svg" alt="Deploy to DO">
   </a>
 </p>


### PR DESCRIPTION
This PR adds a '1-click deploy to Digital Ocean' button to the README and adds a Digital Ocean app template to specify the ENV variables to use for the deploy.

Quick video of the flow. Note that DO by default does not pick their cheap $5 instance, but instead a $12 instance. You have to manually downgrade the instance.

https://user-images.githubusercontent.com/2985976/218287328-9fdb629b-7da1-47d0-9014-6576f3115b31.mov

I need to remove the `--debug` I added in from the Dockerfile and update the links from my fork to this repo before merging.