### PR TITLE
where possible store the SourceURI with the resource.

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
-    <data-source source="LOCAL" name="fasten" uuid="b32d1214-0f9b-4c79-b291-d03ac069209e">
+    <data-source source="LOCAL" name="fasten" uuid="d164a8cf-0ebf-4a73-b7a0-59097243fbce">
       <driver-ref>sqlite.xerial</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>org.sqlite.JDBC</jdbc-driver>

--- a/backend/pkg/database/sqlite_repository.go
+++ b/backend/pkg/database/sqlite_repository.go
@@ -250,6 +250,7 @@ func (sr *SqliteRepository) GetSummary(ctx context.Context) (*models.Summary, er
 
 //This function will create a new resource if it does not exist, or update an existing resource if it does exist.
 //It will also create associations between fhir resources
+//This function is called directly by fasten-sources
 func (sr *SqliteRepository) UpsertRawResource(ctx context.Context, sourceCredential sourceModel.SourceCredential, rawResource sourceModel.RawResourceFhir) (bool, error) {
 
 	source := sourceCredential.(*models.SourceCredential)
@@ -267,6 +268,9 @@ func (sr *SqliteRepository) UpsertRawResource(ctx context.Context, sourceCredent
 		SortDate:        rawResource.SortDate,
 		ResourceRaw:     datatypes.JSON(rawResource.ResourceRaw),
 		RelatedResource: nil,
+	}
+	if len(rawResource.SourceUri) > 0 {
+		wrappedResourceModel.SourceUri = &rawResource.SourceUri
 	}
 
 	//create associations
@@ -332,6 +336,7 @@ func (sr *SqliteRepository) UpsertResource(ctx context.Context, wrappedResourceM
 	wrappedFhirResourceModel.SetOriginBase(wrappedResourceModel.OriginBase)
 	wrappedFhirResourceModel.SetSortTitle(wrappedResourceModel.SortTitle)
 	wrappedFhirResourceModel.SetSortDate(wrappedResourceModel.SortDate)
+	wrappedFhirResourceModel.SetSourceUri(wrappedResourceModel.SourceUri)
 
 	//TODO: this takes too long, we need to find a way to do this processing faster or in the background async.
 	err = wrappedFhirResourceModel.PopulateAndExtractSearchParameters(json.RawMessage(wrappedResourceModel.ResourceRaw))

--- a/backend/pkg/database/sqlite_repository_query_sql_test.go
+++ b/backend/pkg/database/sqlite_repository_query_sql_test.go
@@ -132,14 +132,14 @@ func (suite *RepositorySqlTestSuite) TestQueryResources_SQL_WithMultipleWhereCon
 	require.Equal(suite.T(),
 		strings.Join([]string{
 			"SELECT fhir.*",
-			"FROM fhir_observation as fhir, json_each(fhir.code) as codeJson",
-			"WHERE ((codeJson.value ->> '$.code' = ?)) AND (user_id = ?)",
+			"FROM fhir_observation as fhir, json_each(fhir.code) as codeJson, json_each(fhir.category) as categoryJson",
+			"WHERE ((codeJson.value ->> '$.code' = ?)) AND ((categoryJson.value ->> '$.code' = ?)) AND (user_id = ?)",
 			"GROUP BY `fhir`.`id`",
 			"ORDER BY fhir.sort_date ASC",
 		}, " "),
 		sqlString)
 	require.Equal(suite.T(), sqlParams, []interface{}{
-		"test_code", "00000000-0000-0000-0000-000000000000",
+		"test_code", "12345", "00000000-0000-0000-0000-000000000000",
 	})
 }
 
@@ -154,10 +154,10 @@ func (suite *RepositorySqlTestSuite) TestQueryResources_SQL_WithPrimitiveOrderBy
 	sqlQuery, err := sqliteRepo.sqlQueryResources(authContext, models.QueryResource{
 		Select: []string{},
 		Where: map[string]interface{}{
-			"code": "test_code",
+			"activityCode": "test_code",
 		},
-		From:         "Observation",
-		Aggregations: &models.QueryResourceAggregations{OrderBy: "sourceUri"},
+		From:         "CarePlan",
+		Aggregations: &models.QueryResourceAggregations{OrderBy: "instantiatesUri"},
 	})
 	require.NoError(suite.T(), err)
 	var results []map[string]interface{}
@@ -170,10 +170,10 @@ func (suite *RepositorySqlTestSuite) TestQueryResources_SQL_WithPrimitiveOrderBy
 	require.Equal(suite.T(),
 		strings.Join([]string{
 			"SELECT fhir.*",
-			"FROM fhir_observation as fhir, json_each(fhir.code) as codeJson",
-			"WHERE ((codeJson.value ->> '$.code' = ?)) AND (user_id = ?)",
+			"FROM fhir_care_plan as fhir, json_each(fhir.activityCode) as activityCodeJson",
+			"WHERE ((activityCodeJson.value ->> '$.code' = ?)) AND (user_id = ?)",
 			"GROUP BY `fhir`.`id`",
-			"ORDER BY fhir.sourceUri ASC",
+			"ORDER BY fhir.instantiatesUri ASC",
 		}, " "), sqlString)
 	require.Equal(suite.T(), sqlParams, []interface{}{
 		"test_code", "00000000-0000-0000-0000-000000000000",
@@ -228,10 +228,10 @@ func (suite *RepositorySqlTestSuite) TestQueryResources_SQL_WithPrimitiveCountBy
 	sqlQuery, err := sqliteRepo.sqlQueryResources(authContext, models.QueryResource{
 		Select: []string{},
 		Where: map[string]interface{}{
-			"code": "test_code",
+			"activityCode": "test_code",
 		},
-		From:         "Observation",
-		Aggregations: &models.QueryResourceAggregations{CountBy: "sourceUri"},
+		From:         "CarePlan",
+		Aggregations: &models.QueryResourceAggregations{CountBy: "instantiatesUri"},
 	})
 	require.NoError(suite.T(), err)
 	var results []map[string]interface{}
@@ -243,10 +243,10 @@ func (suite *RepositorySqlTestSuite) TestQueryResources_SQL_WithPrimitiveCountBy
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(),
 		strings.Join([]string{
-			"SELECT fhir.sourceUri as label, count(*) as value",
-			"FROM fhir_observation as fhir, json_each(fhir.code) as codeJson",
-			"WHERE ((codeJson.value ->> '$.code' = ?)) AND (user_id = ?)",
-			"GROUP BY `fhir`.`sourceUri`",
+			"SELECT fhir.instantiatesUri as label, count(*) as value",
+			"FROM fhir_care_plan as fhir, json_each(fhir.activityCode) as activityCodeJson",
+			"WHERE ((activityCodeJson.value ->> '$.code' = ?)) AND (user_id = ?)",
+			"GROUP BY `fhir`.`instantiatesUri`",
 			"ORDER BY count(*) DESC",
 		}, " "), sqlString)
 	require.Equal(suite.T(), sqlParams, []interface{}{

--- a/backend/pkg/database/sqlite_repository_query_test.go
+++ b/backend/pkg/database/sqlite_repository_query_test.go
@@ -238,7 +238,7 @@ func (suite *RepositoryTestSuite) TestQueryResources_SQL() {
 			"SELECT fhir.*",
 			"FROM fhir_observation as fhir, json_each(fhir.code) as codeJson",
 			"WHERE ((codeJson.value ->> '$.code' = ?)) AND (user_id = ?) GROUP BY `fhir`.`id`",
-			"ORDER BY fhir.sort_date asc"}, " "))
+			"ORDER BY fhir.sort_date ASC"}, " "))
 	require.Equal(suite.T(), sqlParams, []interface{}{
 		"test_code", "00000000-0000-0000-0000-000000000000",
 	})

--- a/backend/pkg/models/database/fhir_account.go
+++ b/backend/pkg/models/database/fhir_account.go
@@ -35,9 +35,6 @@ type FhirAccount struct {
 	// Profiles this resource claims to conform to
 	// https://hl7.org/fhir/r4/search.html#reference
 	Profile datatypes.JSON `gorm:"column:profile;type:text;serializer:json" json:"profile,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// active | inactive | entered-in-error | on-hold | unknown
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -64,7 +61,6 @@ func (s *FhirAccount) GetSearchParameters() map[string]string {
 		"owner":       "reference",
 		"period":      "date",
 		"profile":     "reference",
-		"sourceUri":   "uri",
 		"status":      "token",
 		"subject":     "reference",
 		"tag":         "token",
@@ -306,11 +302,6 @@ func (s *FhirAccount) PopulateAndExtractSearchParameters(resourceRaw json.RawMes
 						 `)
 	if err == nil && profileResult.String() != "undefined" {
 		s.Profile = []byte(profileResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_adverse_event.go
+++ b/backend/pkg/models/database/fhir_adverse_event.go
@@ -50,9 +50,6 @@ type FhirAdverseEvent struct {
 	// mild | moderate | severe
 	// https://hl7.org/fhir/r4/search.html#token
 	Severity datatypes.JSON `gorm:"column:severity;type:text;serializer:json" json:"severity,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// AdverseEvent.study
 	// https://hl7.org/fhir/r4/search.html#reference
 	Study datatypes.JSON `gorm:"column:study;type:text;serializer:json" json:"study,omitempty"`
@@ -87,7 +84,6 @@ func (s *FhirAdverseEvent) GetSearchParameters() map[string]string {
 		"resultingcondition": "reference",
 		"seriousness":        "token",
 		"severity":           "token",
-		"sourceUri":          "uri",
 		"study":              "reference",
 		"subject":            "reference",
 		"substance":          "reference",
@@ -487,11 +483,6 @@ func (s *FhirAdverseEvent) PopulateAndExtractSearchParameters(resourceRaw json.R
 						 `)
 	if err == nil && severityResult.String() != "undefined" {
 		s.Severity = []byte(severityResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Study
 	studyResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_allergy_intolerance.go
+++ b/backend/pkg/models/database/fhir_allergy_intolerance.go
@@ -132,9 +132,6 @@ type FhirAllergyIntolerance struct {
 	// mild | moderate | severe (of event as a whole)
 	// https://hl7.org/fhir/r4/search.html#token
 	Severity datatypes.JSON `gorm:"column:severity;type:text;serializer:json" json:"severity,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Tags applied to this resource
 	// https://hl7.org/fhir/r4/search.html#token
 	Tag datatypes.JSON `gorm:"column:tag;type:text;serializer:json" json:"tag,omitempty"`
@@ -167,7 +164,6 @@ func (s *FhirAllergyIntolerance) GetSearchParameters() map[string]string {
 		"recorder":           "reference",
 		"route":              "token",
 		"severity":           "token",
-		"sourceUri":          "uri",
 		"tag":                "token",
 		"text":               "string",
 		"type":               "special",
@@ -718,11 +714,6 @@ func (s *FhirAllergyIntolerance) PopulateAndExtractSearchParameters(resourceRaw 
 						 `)
 	if err == nil && severityResult.String() != "undefined" {
 		s.Severity = []byte(severityResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Tag
 	tagResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_appointment.go
+++ b/backend/pkg/models/database/fhir_appointment.go
@@ -62,9 +62,6 @@ type FhirAppointment struct {
 	// The slots that this appointment is filling
 	// https://hl7.org/fhir/r4/search.html#reference
 	Slot datatypes.JSON `gorm:"column:slot;type:text;serializer:json" json:"slot,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// The specialty of a practitioner that would be required to perform the service requested in this appointment
 	// https://hl7.org/fhir/r4/search.html#token
 	Specialty datatypes.JSON `gorm:"column:specialty;type:text;serializer:json" json:"specialty,omitempty"`
@@ -103,7 +100,6 @@ func (s *FhirAppointment) GetSearchParameters() map[string]string {
 		"serviceCategory": "token",
 		"serviceType":     "token",
 		"slot":            "reference",
-		"sourceUri":       "uri",
 		"specialty":       "token",
 		"status":          "token",
 		"supportingInfo":  "reference",
@@ -592,11 +588,6 @@ func (s *FhirAppointment) PopulateAndExtractSearchParameters(resourceRaw json.Ra
 						 `)
 	if err == nil && slotResult.String() != "undefined" {
 		s.Slot = []byte(slotResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Specialty
 	specialtyResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_binary.go
+++ b/backend/pkg/models/database/fhir_binary.go
@@ -23,9 +23,6 @@ type FhirBinary struct {
 	// Profiles this resource claims to conform to
 	// https://hl7.org/fhir/r4/search.html#reference
 	Profile datatypes.JSON `gorm:"column:profile;type:text;serializer:json" json:"profile,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Tags applied to this resource
 	// https://hl7.org/fhir/r4/search.html#token
 	Tag datatypes.JSON `gorm:"column:tag;type:text;serializer:json" json:"tag,omitempty"`
@@ -42,7 +39,6 @@ func (s *FhirBinary) GetSearchParameters() map[string]string {
 		"language":    "token",
 		"lastUpdated": "date",
 		"profile":     "reference",
-		"sourceUri":   "uri",
 		"tag":         "token",
 		"text":        "string",
 		"type":        "special",
@@ -149,11 +145,6 @@ func (s *FhirBinary) PopulateAndExtractSearchParameters(resourceRaw json.RawMess
 						 `)
 	if err == nil && profileResult.String() != "undefined" {
 		s.Profile = []byte(profileResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Tag
 	tagResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_care_plan.go
+++ b/backend/pkg/models/database/fhir_care_plan.go
@@ -127,9 +127,6 @@ type FhirCarePlan struct {
 	// CarePlan replaced by this CarePlan
 	// https://hl7.org/fhir/r4/search.html#reference
 	Replaces datatypes.JSON `gorm:"column:replaces;type:text;serializer:json" json:"replaces,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// draft | active | on-hold | revoked | completed | entered-in-error | unknown
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -169,7 +166,6 @@ func (s *FhirCarePlan) GetSearchParameters() map[string]string {
 		"performer":             "reference",
 		"profile":               "reference",
 		"replaces":              "reference",
-		"sourceUri":             "uri",
 		"status":                "token",
 		"subject":               "reference",
 		"tag":                   "token",
@@ -637,11 +633,6 @@ func (s *FhirCarePlan) PopulateAndExtractSearchParameters(resourceRaw json.RawMe
 						 `)
 	if err == nil && replacesResult.String() != "undefined" {
 		s.Replaces = []byte(replacesResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_care_team.go
+++ b/backend/pkg/models/database/fhir_care_team.go
@@ -91,9 +91,6 @@ type FhirCareTeam struct {
 	// Profiles this resource claims to conform to
 	// https://hl7.org/fhir/r4/search.html#reference
 	Profile datatypes.JSON `gorm:"column:profile;type:text;serializer:json" json:"profile,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// proposed | active | suspended | inactive | entered-in-error
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -121,7 +118,6 @@ func (s *FhirCareTeam) GetSearchParameters() map[string]string {
 		"lastUpdated": "date",
 		"participant": "reference",
 		"profile":     "reference",
-		"sourceUri":   "uri",
 		"status":      "token",
 		"subject":     "reference",
 		"tag":         "token",
@@ -365,11 +361,6 @@ func (s *FhirCareTeam) PopulateAndExtractSearchParameters(resourceRaw json.RawMe
 						 `)
 	if err == nil && profileResult.String() != "undefined" {
 		s.Profile = []byte(profileResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_claim.go
+++ b/backend/pkg/models/database/fhir_claim.go
@@ -62,9 +62,6 @@ type FhirClaim struct {
 	// Provider responsible for the Claim
 	// https://hl7.org/fhir/r4/search.html#reference
 	Provider datatypes.JSON `gorm:"column:provider;type:text;serializer:json" json:"provider,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// The status of the Claim instance.
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -103,7 +100,6 @@ func (s *FhirClaim) GetSearchParameters() map[string]string {
 		"procedureUdi": "reference",
 		"profile":      "reference",
 		"provider":     "reference",
-		"sourceUri":    "uri",
 		"status":       "token",
 		"subdetailUdi": "reference",
 		"tag":          "token",
@@ -460,11 +456,6 @@ func (s *FhirClaim) PopulateAndExtractSearchParameters(resourceRaw json.RawMessa
 						 `)
 	if err == nil && providerResult.String() != "undefined" {
 		s.Provider = []byte(providerResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_claim_response.go
+++ b/backend/pkg/models/database/fhir_claim_response.go
@@ -47,9 +47,6 @@ type FhirClaimResponse struct {
 	// The Provider of the claim
 	// https://hl7.org/fhir/r4/search.html#reference
 	Requestor datatypes.JSON `gorm:"column:requestor;type:text;serializer:json" json:"requestor,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// The status of the ClaimResponse
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -80,7 +77,6 @@ func (s *FhirClaimResponse) GetSearchParameters() map[string]string {
 		"profile":     "reference",
 		"request":     "reference",
 		"requestor":   "reference",
-		"sourceUri":   "uri",
 		"status":      "token",
 		"tag":         "token",
 		"text":        "string",
@@ -410,11 +406,6 @@ func (s *FhirClaimResponse) PopulateAndExtractSearchParameters(resourceRaw json.
 						 `)
 	if err == nil && requestorResult.String() != "undefined" {
 		s.Requestor = []byte(requestorResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_composition.go
+++ b/backend/pkg/models/database/fhir_composition.go
@@ -130,9 +130,6 @@ type FhirComposition struct {
 	// Classification of section (recommended)
 	// https://hl7.org/fhir/r4/search.html#token
 	Section datatypes.JSON `gorm:"column:section;type:text;serializer:json" json:"section,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// preliminary | final | amended | entered-in-error
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -171,7 +168,6 @@ func (s *FhirComposition) GetSearchParameters() map[string]string {
 		"relatedId":       "token",
 		"relatedRef":      "reference",
 		"section":         "token",
-		"sourceUri":       "uri",
 		"status":          "token",
 		"subject":         "reference",
 		"tag":             "token",
@@ -659,11 +655,6 @@ func (s *FhirComposition) PopulateAndExtractSearchParameters(resourceRaw json.Ra
 						 `)
 	if err == nil && sectionResult.String() != "undefined" {
 		s.Section = []byte(sectionResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_condition.go
+++ b/backend/pkg/models/database/fhir_condition.go
@@ -124,9 +124,6 @@ type FhirCondition struct {
 	// The severity of the condition
 	// https://hl7.org/fhir/r4/search.html#token
 	Severity datatypes.JSON `gorm:"column:severity;type:text;serializer:json" json:"severity,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Simple summary (disease specific)
 	// https://hl7.org/fhir/r4/search.html#token
 	Stage datatypes.JSON `gorm:"column:stage;type:text;serializer:json" json:"stage,omitempty"`
@@ -169,7 +166,6 @@ func (s *FhirCondition) GetSearchParameters() map[string]string {
 		"profile":            "reference",
 		"recordedDate":       "date",
 		"severity":           "token",
-		"sourceUri":          "uri",
 		"stage":              "token",
 		"subject":            "reference",
 		"tag":                "token",
@@ -817,11 +813,6 @@ func (s *FhirCondition) PopulateAndExtractSearchParameters(resourceRaw json.RawM
 						 `)
 	if err == nil && severityResult.String() != "undefined" {
 		s.Severity = []byte(severityResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Stage
 	stageResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_consent.go
+++ b/backend/pkg/models/database/fhir_consent.go
@@ -115,9 +115,6 @@ type FhirConsent struct {
 	// Search by reference to a Consent, DocumentReference, Contract  or QuestionnaireResponse
 	// https://hl7.org/fhir/r4/search.html#reference
 	SourceReference datatypes.JSON `gorm:"column:sourceReference;type:text;serializer:json" json:"sourceReference,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// draft | proposed | active | rejected | inactive | entered-in-error
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -150,7 +147,6 @@ func (s *FhirConsent) GetSearchParameters() map[string]string {
 		"scope":           "token",
 		"securityLabel":   "token",
 		"sourceReference": "reference",
-		"sourceUri":       "uri",
 		"status":          "token",
 		"tag":             "token",
 		"text":            "string",
@@ -636,11 +632,6 @@ func (s *FhirConsent) PopulateAndExtractSearchParameters(resourceRaw json.RawMes
 						 `)
 	if err == nil && sourceReferenceResult.String() != "undefined" {
 		s.SourceReference = []byte(sourceReferenceResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_coverage.go
+++ b/backend/pkg/models/database/fhir_coverage.go
@@ -44,9 +44,6 @@ type FhirCoverage struct {
 	// Profiles this resource claims to conform to
 	// https://hl7.org/fhir/r4/search.html#reference
 	Profile datatypes.JSON `gorm:"column:profile;type:text;serializer:json" json:"profile,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// The status of the Coverage
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -76,7 +73,6 @@ func (s *FhirCoverage) GetSearchParameters() map[string]string {
 		"payor":        "reference",
 		"policyHolder": "reference",
 		"profile":      "reference",
-		"sourceUri":    "uri",
 		"status":       "token",
 		"subscriber":   "reference",
 		"tag":          "token",
@@ -439,11 +435,6 @@ func (s *FhirCoverage) PopulateAndExtractSearchParameters(resourceRaw json.RawMe
 						 `)
 	if err == nil && profileResult.String() != "undefined" {
 		s.Profile = []byte(profileResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_coverage_eligibility_request.go
+++ b/backend/pkg/models/database/fhir_coverage_eligibility_request.go
@@ -38,9 +38,6 @@ type FhirCoverageEligibilityRequest struct {
 	// The reference to the provider
 	// https://hl7.org/fhir/r4/search.html#reference
 	Provider datatypes.JSON `gorm:"column:provider;type:text;serializer:json" json:"provider,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// The status of the EligibilityRequest
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -65,7 +62,6 @@ func (s *FhirCoverageEligibilityRequest) GetSearchParameters() map[string]string
 		"lastUpdated": "date",
 		"profile":     "reference",
 		"provider":    "reference",
-		"sourceUri":   "uri",
 		"status":      "token",
 		"tag":         "token",
 		"text":        "string",
@@ -275,11 +271,6 @@ func (s *FhirCoverageEligibilityRequest) PopulateAndExtractSearchParameters(reso
 						 `)
 	if err == nil && providerResult.String() != "undefined" {
 		s.Provider = []byte(providerResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_coverage_eligibility_response.go
+++ b/backend/pkg/models/database/fhir_coverage_eligibility_response.go
@@ -44,9 +44,6 @@ type FhirCoverageEligibilityResponse struct {
 	// The EligibilityRequest provider
 	// https://hl7.org/fhir/r4/search.html#reference
 	Requestor datatypes.JSON `gorm:"column:requestor;type:text;serializer:json" json:"requestor,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// The EligibilityRequest status
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -73,7 +70,6 @@ func (s *FhirCoverageEligibilityResponse) GetSearchParameters() map[string]strin
 		"profile":     "reference",
 		"request":     "reference",
 		"requestor":   "reference",
-		"sourceUri":   "uri",
 		"status":      "token",
 		"tag":         "token",
 		"text":        "string",
@@ -389,11 +385,6 @@ func (s *FhirCoverageEligibilityResponse) PopulateAndExtractSearchParameters(res
 						 `)
 	if err == nil && requestorResult.String() != "undefined" {
 		s.Requestor = []byte(requestorResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_device.go
+++ b/backend/pkg/models/database/fhir_device.go
@@ -41,9 +41,6 @@ type FhirDevice struct {
 	// Profiles this resource claims to conform to
 	// https://hl7.org/fhir/r4/search.html#reference
 	Profile datatypes.JSON `gorm:"column:profile;type:text;serializer:json" json:"profile,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// active | inactive | entered-in-error | unknown
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -78,7 +75,6 @@ func (s *FhirDevice) GetSearchParameters() map[string]string {
 		"model":        "string",
 		"organization": "reference",
 		"profile":      "reference",
-		"sourceUri":    "uri",
 		"status":       "token",
 		"tag":          "token",
 		"text":         "string",
@@ -441,11 +437,6 @@ func (s *FhirDevice) PopulateAndExtractSearchParameters(resourceRaw json.RawMess
 						 `)
 	if err == nil && profileResult.String() != "undefined" {
 		s.Profile = []byte(profileResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_device_request.go
+++ b/backend/pkg/models/database/fhir_device_request.go
@@ -133,9 +133,6 @@ type FhirDeviceRequest struct {
 	// Who/what is requesting service
 	// https://hl7.org/fhir/r4/search.html#reference
 	Requester datatypes.JSON `gorm:"column:requester;type:text;serializer:json" json:"requester,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// entered-in-error | draft | active |suspended | completed
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -173,7 +170,6 @@ func (s *FhirDeviceRequest) GetSearchParameters() map[string]string {
 		"priorRequest":          "reference",
 		"profile":               "reference",
 		"requester":             "reference",
-		"sourceUri":             "uri",
 		"status":                "token",
 		"subject":               "reference",
 		"tag":                   "token",
@@ -613,11 +609,6 @@ func (s *FhirDeviceRequest) PopulateAndExtractSearchParameters(resourceRaw json.
 						 `)
 	if err == nil && requesterResult.String() != "undefined" {
 		s.Requester = []byte(requesterResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_diagnostic_report.go
+++ b/backend/pkg/models/database/fhir_diagnostic_report.go
@@ -144,9 +144,6 @@ type FhirDiagnosticReport struct {
 	// Who was the source of the report
 	// https://hl7.org/fhir/r4/search.html#reference
 	ResultsInterpreter datatypes.JSON `gorm:"column:resultsInterpreter;type:text;serializer:json" json:"resultsInterpreter,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// The specimen details
 	// https://hl7.org/fhir/r4/search.html#reference
 	Specimen datatypes.JSON `gorm:"column:specimen;type:text;serializer:json" json:"specimen,omitempty"`
@@ -184,7 +181,6 @@ func (s *FhirDiagnosticReport) GetSearchParameters() map[string]string {
 		"profile":            "reference",
 		"result":             "reference",
 		"resultsInterpreter": "reference",
-		"sourceUri":          "uri",
 		"specimen":           "reference",
 		"status":             "token",
 		"subject":            "reference",
@@ -592,11 +588,6 @@ func (s *FhirDiagnosticReport) PopulateAndExtractSearchParameters(resourceRaw js
 						 `)
 	if err == nil && resultsInterpreterResult.String() != "undefined" {
 		s.ResultsInterpreter = []byte(resultsInterpreterResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Specimen
 	specimenResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_document_manifest.go
+++ b/backend/pkg/models/database/fhir_document_manifest.go
@@ -83,9 +83,6 @@ type FhirDocumentManifest struct {
 	// The source system/application/software
 	// https://hl7.org/fhir/r4/search.html#uri
 	Source string `gorm:"column:source;type:text" json:"source,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// current | superseded | entered-in-error
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -117,7 +114,6 @@ func (s *FhirDocumentManifest) GetSearchParameters() map[string]string {
 		"relatedId":   "token",
 		"relatedRef":  "reference",
 		"source":      "uri",
-		"sourceUri":   "uri",
 		"status":      "token",
 		"subject":     "reference",
 		"tag":         "token",
@@ -453,11 +449,6 @@ func (s *FhirDocumentManifest) PopulateAndExtractSearchParameters(resourceRaw js
 	sourceResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'DocumentManifest.source')[0]")
 	if err == nil && sourceResult.String() != "undefined" {
 		s.Source = sourceResult.String()
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_document_reference.go
+++ b/backend/pkg/models/database/fhir_document_reference.go
@@ -128,9 +128,6 @@ type FhirDocumentReference struct {
 	// Additional details about where the content was created (e.g. clinical specialty)
 	// https://hl7.org/fhir/r4/search.html#token
 	Setting datatypes.JSON `gorm:"column:setting;type:text;serializer:json" json:"setting,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// current | superseded | entered-in-error
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -172,7 +169,6 @@ func (s *FhirDocumentReference) GetSearchParameters() map[string]string {
 		"relation":      "token",
 		"securityLabel": "token",
 		"setting":       "token",
-		"sourceUri":     "uri",
 		"status":        "token",
 		"subject":       "reference",
 		"tag":           "token",
@@ -878,11 +874,6 @@ func (s *FhirDocumentReference) PopulateAndExtractSearchParameters(resourceRaw j
 						 `)
 	if err == nil && settingResult.String() != "undefined" {
 		s.Setting = []byte(settingResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_encounter.go
+++ b/backend/pkg/models/database/fhir_encounter.go
@@ -130,9 +130,6 @@ type FhirEncounter struct {
 	// The organization (facility) responsible for this encounter
 	// https://hl7.org/fhir/r4/search.html#reference
 	ServiceProvider datatypes.JSON `gorm:"column:serviceProvider;type:text;serializer:json" json:"serviceProvider,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Wheelchair, translator, stretcher, etc.
 	// https://hl7.org/fhir/r4/search.html#token
 	SpecialArrangement datatypes.JSON `gorm:"column:specialArrangement;type:text;serializer:json" json:"specialArrangement,omitempty"`
@@ -176,7 +173,6 @@ func (s *FhirEncounter) GetSearchParameters() map[string]string {
 		"reasonCode":         "token",
 		"reasonReference":    "reference",
 		"serviceProvider":    "reference",
-		"sourceUri":          "uri",
 		"specialArrangement": "token",
 		"status":             "token",
 		"subject":            "reference",
@@ -659,11 +655,6 @@ func (s *FhirEncounter) PopulateAndExtractSearchParameters(resourceRaw json.RawM
 						 `)
 	if err == nil && serviceProviderResult.String() != "undefined" {
 		s.ServiceProvider = []byte(serviceProviderResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting SpecialArrangement
 	specialArrangementResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_endpoint.go
+++ b/backend/pkg/models/database/fhir_endpoint.go
@@ -38,9 +38,6 @@ type FhirEndpoint struct {
 	// Profiles this resource claims to conform to
 	// https://hl7.org/fhir/r4/search.html#reference
 	Profile datatypes.JSON `gorm:"column:profile;type:text;serializer:json" json:"profile,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// The current status of the Endpoint (usually expected to be active)
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -65,7 +62,6 @@ func (s *FhirEndpoint) GetSearchParameters() map[string]string {
 		"organization":   "reference",
 		"payloadType":    "token",
 		"profile":        "reference",
-		"sourceUri":      "uri",
 		"status":         "token",
 		"tag":            "token",
 		"text":           "string",
@@ -387,11 +383,6 @@ func (s *FhirEndpoint) PopulateAndExtractSearchParameters(resourceRaw json.RawMe
 						 `)
 	if err == nil && profileResult.String() != "undefined" {
 		s.Profile = []byte(profileResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_enrollment_request.go
+++ b/backend/pkg/models/database/fhir_enrollment_request.go
@@ -26,9 +26,6 @@ type FhirEnrollmentRequest struct {
 	// Profiles this resource claims to conform to
 	// https://hl7.org/fhir/r4/search.html#reference
 	Profile datatypes.JSON `gorm:"column:profile;type:text;serializer:json" json:"profile,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// The status of the enrollment
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -52,7 +49,6 @@ func (s *FhirEnrollmentRequest) GetSearchParameters() map[string]string {
 		"language":    "token",
 		"lastUpdated": "date",
 		"profile":     "reference",
-		"sourceUri":   "uri",
 		"status":      "token",
 		"subject":     "reference",
 		"tag":         "token",
@@ -208,11 +204,6 @@ func (s *FhirEnrollmentRequest) PopulateAndExtractSearchParameters(resourceRaw j
 						 `)
 	if err == nil && profileResult.String() != "undefined" {
 		s.Profile = []byte(profileResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_enrollment_response.go
+++ b/backend/pkg/models/database/fhir_enrollment_response.go
@@ -29,9 +29,6 @@ type FhirEnrollmentResponse struct {
 	// The reference to the claim
 	// https://hl7.org/fhir/r4/search.html#reference
 	Request datatypes.JSON `gorm:"column:request;type:text;serializer:json" json:"request,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// The status of the enrollment response
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -53,7 +50,6 @@ func (s *FhirEnrollmentResponse) GetSearchParameters() map[string]string {
 		"lastUpdated": "date",
 		"profile":     "reference",
 		"request":     "reference",
-		"sourceUri":   "uri",
 		"status":      "token",
 		"tag":         "token",
 		"text":        "string",
@@ -222,11 +218,6 @@ func (s *FhirEnrollmentResponse) PopulateAndExtractSearchParameters(resourceRaw 
 						 `)
 	if err == nil && requestResult.String() != "undefined" {
 		s.Request = []byte(requestResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_explanation_of_benefit.go
+++ b/backend/pkg/models/database/fhir_explanation_of_benefit.go
@@ -65,9 +65,6 @@ type FhirExplanationOfBenefit struct {
 	// The reference to the provider
 	// https://hl7.org/fhir/r4/search.html#reference
 	Provider datatypes.JSON `gorm:"column:provider;type:text;serializer:json" json:"provider,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Status of the instance
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -104,7 +101,6 @@ func (s *FhirExplanationOfBenefit) GetSearchParameters() map[string]string {
 		"procedureUdi": "reference",
 		"profile":      "reference",
 		"provider":     "reference",
-		"sourceUri":    "uri",
 		"status":       "token",
 		"subdetailUdi": "reference",
 		"tag":          "token",
@@ -486,11 +482,6 @@ func (s *FhirExplanationOfBenefit) PopulateAndExtractSearchParameters(resourceRa
 						 `)
 	if err == nil && providerResult.String() != "undefined" {
 		s.Provider = []byte(providerResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_family_member_history.go
+++ b/backend/pkg/models/database/fhir_family_member_history.go
@@ -114,9 +114,6 @@ type FhirFamilyMemberHistory struct {
 	// A search by a sex code of a family member
 	// https://hl7.org/fhir/r4/search.html#token
 	Sex datatypes.JSON `gorm:"column:sex;type:text;serializer:json" json:"sex,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// partial | completed | entered-in-error | health-unknown
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -143,7 +140,6 @@ func (s *FhirFamilyMemberHistory) GetSearchParameters() map[string]string {
 		"profile":               "reference",
 		"relationship":          "token",
 		"sex":                   "token",
-		"sourceUri":             "uri",
 		"status":                "token",
 		"tag":                   "token",
 		"text":                  "string",
@@ -471,11 +467,6 @@ func (s *FhirFamilyMemberHistory) PopulateAndExtractSearchParameters(resourceRaw
 						 `)
 	if err == nil && sexResult.String() != "undefined" {
 		s.Sex = []byte(sexResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_goal.go
+++ b/backend/pkg/models/database/fhir_goal.go
@@ -68,9 +68,6 @@ type FhirGoal struct {
 	// Profiles this resource claims to conform to
 	// https://hl7.org/fhir/r4/search.html#reference
 	Profile datatypes.JSON `gorm:"column:profile;type:text;serializer:json" json:"profile,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// When goal pursuit begins
 	// https://hl7.org/fhir/r4/search.html#date
 	StartDate *time.Time `gorm:"column:startDate;type:datetime" json:"startDate,omitempty"`
@@ -100,7 +97,6 @@ func (s *FhirGoal) GetSearchParameters() map[string]string {
 		"lastUpdated":       "date",
 		"lifecycleStatus":   "token",
 		"profile":           "reference",
-		"sourceUri":         "uri",
 		"startDate":         "date",
 		"subject":           "reference",
 		"tag":               "token",
@@ -398,11 +394,6 @@ func (s *FhirGoal) PopulateAndExtractSearchParameters(resourceRaw json.RawMessag
 						 `)
 	if err == nil && profileResult.String() != "undefined" {
 		s.Profile = []byte(profileResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting StartDate
 	startDateResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, '(Goal.startDate)')[0]")

--- a/backend/pkg/models/database/fhir_imaging_study.go
+++ b/backend/pkg/models/database/fhir_imaging_study.go
@@ -95,9 +95,6 @@ type FhirImagingStudy struct {
 	// DICOM Series Instance UID for a series
 	// https://hl7.org/fhir/r4/search.html#token
 	Series datatypes.JSON `gorm:"column:series;type:text;serializer:json" json:"series,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// When the study was started
 	// https://hl7.org/fhir/r4/search.html#date
 	Started *time.Time `gorm:"column:started;type:datetime" json:"started,omitempty"`
@@ -136,7 +133,6 @@ func (s *FhirImagingStudy) GetSearchParameters() map[string]string {
 		"reason":      "token",
 		"referrer":    "reference",
 		"series":      "token",
-		"sourceUri":   "uri",
 		"started":     "date",
 		"status":      "token",
 		"subject":     "reference",
@@ -659,11 +655,6 @@ func (s *FhirImagingStudy) PopulateAndExtractSearchParameters(resourceRaw json.R
 						 `)
 	if err == nil && seriesResult.String() != "undefined" {
 		s.Series = []byte(seriesResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Started
 	startedResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'ImagingStudy.started')[0]")

--- a/backend/pkg/models/database/fhir_immunization.go
+++ b/backend/pkg/models/database/fhir_immunization.go
@@ -109,9 +109,6 @@ type FhirImmunization struct {
 	// The series being followed by the provider
 	// https://hl7.org/fhir/r4/search.html#string
 	Series datatypes.JSON `gorm:"column:series;type:text;serializer:json" json:"series,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Immunization event status
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -151,7 +148,6 @@ func (s *FhirImmunization) GetSearchParameters() map[string]string {
 		"reasonCode":      "token",
 		"reasonReference": "reference",
 		"series":          "string",
-		"sourceUri":       "uri",
 		"status":          "token",
 		"statusReason":    "token",
 		"tag":             "token",
@@ -570,11 +566,6 @@ func (s *FhirImmunization) PopulateAndExtractSearchParameters(resourceRaw json.R
 						 `)
 	if err == nil && seriesResult.String() != "undefined" {
 		s.Series = []byte(seriesResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_insurance_plan.go
+++ b/backend/pkg/models/database/fhir_insurance_plan.go
@@ -59,9 +59,6 @@ type FhirInsurancePlan struct {
 	// Profiles this resource claims to conform to
 	// https://hl7.org/fhir/r4/search.html#reference
 	Profile datatypes.JSON `gorm:"column:profile;type:text;serializer:json" json:"profile,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Is the Organization record active
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -93,7 +90,6 @@ func (s *FhirInsurancePlan) GetSearchParameters() map[string]string {
 		"ownedBy":           "reference",
 		"phonetic":          "string",
 		"profile":           "reference",
-		"sourceUri":         "uri",
 		"status":            "token",
 		"tag":               "token",
 		"text":              "string",
@@ -750,11 +746,6 @@ func (s *FhirInsurancePlan) PopulateAndExtractSearchParameters(resourceRaw json.
 						 `)
 	if err == nil && profileResult.String() != "undefined" {
 		s.Profile = []byte(profileResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_location.go
+++ b/backend/pkg/models/database/fhir_location.go
@@ -59,9 +59,6 @@ type FhirLocation struct {
 	// Profiles this resource claims to conform to
 	// https://hl7.org/fhir/r4/search.html#reference
 	Profile datatypes.JSON `gorm:"column:profile;type:text;serializer:json" json:"profile,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Searches for locations with a specific kind of status
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -93,7 +90,6 @@ func (s *FhirLocation) GetSearchParameters() map[string]string {
 		"organization":      "reference",
 		"partof":            "reference",
 		"profile":           "reference",
-		"sourceUri":         "uri",
 		"status":            "token",
 		"tag":               "token",
 		"text":              "string",
@@ -738,11 +734,6 @@ func (s *FhirLocation) PopulateAndExtractSearchParameters(resourceRaw json.RawMe
 						 `)
 	if err == nil && profileResult.String() != "undefined" {
 		s.Profile = []byte(profileResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_media.go
+++ b/backend/pkg/models/database/fhir_media.go
@@ -47,9 +47,6 @@ type FhirMedia struct {
 	// Observed body part
 	// https://hl7.org/fhir/r4/search.html#token
 	Site datatypes.JSON `gorm:"column:site;type:text;serializer:json" json:"site,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -83,7 +80,6 @@ func (s *FhirMedia) GetSearchParameters() map[string]string {
 		"operator":    "reference",
 		"profile":     "reference",
 		"site":        "token",
-		"sourceUri":   "uri",
 		"status":      "token",
 		"subject":     "reference",
 		"tag":         "token",
@@ -403,11 +399,6 @@ func (s *FhirMedia) PopulateAndExtractSearchParameters(resourceRaw json.RawMessa
 						 `)
 	if err == nil && siteResult.String() != "undefined" {
 		s.Site = []byte(siteResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_medication.go
+++ b/backend/pkg/models/database/fhir_medication.go
@@ -64,9 +64,6 @@ type FhirMedication struct {
 	// Profiles this resource claims to conform to
 	// https://hl7.org/fhir/r4/search.html#reference
 	Profile datatypes.JSON `gorm:"column:profile;type:text;serializer:json" json:"profile,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Returns medications for this status
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -94,7 +91,6 @@ func (s *FhirMedication) GetSearchParameters() map[string]string {
 		"lotNumber":      "token",
 		"manufacturer":   "reference",
 		"profile":        "reference",
-		"sourceUri":      "uri",
 		"status":         "token",
 		"tag":            "token",
 		"text":           "string",
@@ -478,11 +474,6 @@ func (s *FhirMedication) PopulateAndExtractSearchParameters(resourceRaw json.Raw
 						 `)
 	if err == nil && profileResult.String() != "undefined" {
 		s.Profile = []byte(profileResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_medication_administration.go
+++ b/backend/pkg/models/database/fhir_medication_administration.go
@@ -110,9 +110,6 @@ type FhirMedicationAdministration struct {
 	// The identity of a request to list administrations from
 	// https://hl7.org/fhir/r4/search.html#reference
 	Request datatypes.JSON `gorm:"column:request;type:text;serializer:json" json:"request,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	/*
 	   Multiple Resources:
 
@@ -152,7 +149,6 @@ func (s *FhirMedicationAdministration) GetSearchParameters() map[string]string {
 		"reasonGiven":    "token",
 		"reasonNotGiven": "token",
 		"request":        "reference",
-		"sourceUri":      "uri",
 		"status":         "token",
 		"subject":        "reference",
 		"tag":            "token",
@@ -532,11 +528,6 @@ func (s *FhirMedicationAdministration) PopulateAndExtractSearchParameters(resour
 						 `)
 	if err == nil && requestResult.String() != "undefined" {
 		s.Request = []byte(requestResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_medication_dispense.go
+++ b/backend/pkg/models/database/fhir_medication_dispense.go
@@ -111,9 +111,6 @@ type FhirMedicationDispense struct {
 	// Returns dispenses with the specified responsible party
 	// https://hl7.org/fhir/r4/search.html#reference
 	Responsibleparty datatypes.JSON `gorm:"column:responsibleparty;type:text;serializer:json" json:"responsibleparty,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	/*
 	   Multiple Resources:
 
@@ -158,7 +155,6 @@ func (s *FhirMedicationDispense) GetSearchParameters() map[string]string {
 		"profile":          "reference",
 		"receiver":         "reference",
 		"responsibleparty": "reference",
-		"sourceUri":        "uri",
 		"status":           "token",
 		"subject":          "reference",
 		"tag":              "token",
@@ -461,11 +457,6 @@ func (s *FhirMedicationDispense) PopulateAndExtractSearchParameters(resourceRaw 
 						 `)
 	if err == nil && responsiblepartyResult.String() != "undefined" {
 		s.Responsibleparty = []byte(responsiblepartyResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_medication_request.go
+++ b/backend/pkg/models/database/fhir_medication_request.go
@@ -127,9 +127,6 @@ type FhirMedicationRequest struct {
 	// Returns prescriptions prescribed by this prescriber
 	// https://hl7.org/fhir/r4/search.html#reference
 	Requester datatypes.JSON `gorm:"column:requester;type:text;serializer:json" json:"requester,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	/*
 	   Multiple Resources:
 
@@ -172,7 +169,6 @@ func (s *FhirMedicationRequest) GetSearchParameters() map[string]string {
 		"priority":              "token",
 		"profile":               "reference",
 		"requester":             "reference",
-		"sourceUri":             "uri",
 		"status":                "token",
 		"subject":               "reference",
 		"tag":                   "token",
@@ -659,11 +655,6 @@ func (s *FhirMedicationRequest) PopulateAndExtractSearchParameters(resourceRaw j
 						 `)
 	if err == nil && requesterResult.String() != "undefined" {
 		s.Requester = []byte(requesterResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_medication_statement.go
+++ b/backend/pkg/models/database/fhir_medication_statement.go
@@ -104,9 +104,6 @@ type FhirMedicationStatement struct {
 	// Who or where the information in the statement came from
 	// https://hl7.org/fhir/r4/search.html#reference
 	Source datatypes.JSON `gorm:"column:source;type:text;serializer:json" json:"source,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	/*
 	   Multiple Resources:
 
@@ -144,7 +141,6 @@ func (s *FhirMedicationStatement) GetSearchParameters() map[string]string {
 		"partOf":      "reference",
 		"profile":     "reference",
 		"source":      "reference",
-		"sourceUri":   "uri",
 		"status":      "token",
 		"subject":     "reference",
 		"tag":         "token",
@@ -463,11 +459,6 @@ func (s *FhirMedicationStatement) PopulateAndExtractSearchParameters(resourceRaw
 						 `)
 	if err == nil && sourceResult.String() != "undefined" {
 		s.Source = []byte(sourceResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_nutrition_order.go
+++ b/backend/pkg/models/database/fhir_nutrition_order.go
@@ -98,9 +98,6 @@ type FhirNutritionOrder struct {
 	// The identity of the provider who placed the nutrition order
 	// https://hl7.org/fhir/r4/search.html#reference
 	Provider datatypes.JSON `gorm:"column:provider;type:text;serializer:json" json:"provider,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Status of the nutrition order.
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -132,7 +129,6 @@ func (s *FhirNutritionOrder) GetSearchParameters() map[string]string {
 		"oraldiet":              "token",
 		"profile":               "reference",
 		"provider":              "reference",
-		"sourceUri":             "uri",
 		"status":                "token",
 		"supplement":            "token",
 		"tag":                   "token",
@@ -489,11 +485,6 @@ func (s *FhirNutritionOrder) PopulateAndExtractSearchParameters(resourceRaw json
 						 `)
 	if err == nil && providerResult.String() != "undefined" {
 		s.Provider = []byte(providerResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_observation.go
+++ b/backend/pkg/models/database/fhir_observation.go
@@ -174,9 +174,6 @@ type FhirObservation struct {
 	// Profiles this resource claims to conform to
 	// https://hl7.org/fhir/r4/search.html#reference
 	Profile datatypes.JSON `gorm:"column:profile;type:text;serializer:json" json:"profile,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Specimen used for this observation
 	// https://hl7.org/fhir/r4/search.html#reference
 	Specimen datatypes.JSON `gorm:"column:specimen;type:text;serializer:json" json:"specimen,omitempty"`
@@ -236,7 +233,6 @@ func (s *FhirObservation) GetSearchParameters() map[string]string {
 		"partOf":                    "reference",
 		"performer":                 "reference",
 		"profile":                   "reference",
-		"sourceUri":                 "uri",
 		"specimen":                  "reference",
 		"status":                    "token",
 		"subject":                   "reference",
@@ -1002,11 +998,6 @@ func (s *FhirObservation) PopulateAndExtractSearchParameters(resourceRaw json.Ra
 						 `)
 	if err == nil && profileResult.String() != "undefined" {
 		s.Profile = []byte(profileResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Specimen
 	specimenResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_organization.go
+++ b/backend/pkg/models/database/fhir_organization.go
@@ -59,9 +59,6 @@ type FhirOrganization struct {
 	// Profiles this resource claims to conform to
 	// https://hl7.org/fhir/r4/search.html#reference
 	Profile datatypes.JSON `gorm:"column:profile;type:text;serializer:json" json:"profile,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Tags applied to this resource
 	// https://hl7.org/fhir/r4/search.html#token
 	Tag datatypes.JSON `gorm:"column:tag;type:text;serializer:json" json:"tag,omitempty"`
@@ -90,7 +87,6 @@ func (s *FhirOrganization) GetSearchParameters() map[string]string {
 		"partof":            "reference",
 		"phonetic":          "string",
 		"profile":           "reference",
-		"sourceUri":         "uri",
 		"tag":               "token",
 		"text":              "string",
 		"type":              "special",
@@ -779,11 +775,6 @@ func (s *FhirOrganization) PopulateAndExtractSearchParameters(resourceRaw json.R
 						 `)
 	if err == nil && profileResult.String() != "undefined" {
 		s.Profile = []byte(profileResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Tag
 	tagResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_organization_affiliation.go
+++ b/backend/pkg/models/database/fhir_organization_affiliation.go
@@ -59,9 +59,6 @@ type FhirOrganizationAffiliation struct {
 	// Healthcare services provided through the role
 	// https://hl7.org/fhir/r4/search.html#reference
 	Service datatypes.JSON `gorm:"column:service;type:text;serializer:json" json:"service,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Specific specialty of the participatingOrganization in the context of the role
 	// https://hl7.org/fhir/r4/search.html#token
 	Specialty datatypes.JSON `gorm:"column:specialty;type:text;serializer:json" json:"specialty,omitempty"`
@@ -96,7 +93,6 @@ func (s *FhirOrganizationAffiliation) GetSearchParameters() map[string]string {
 		"profile":                   "reference",
 		"role":                      "token",
 		"service":                   "reference",
-		"sourceUri":                 "uri",
 		"specialty":                 "token",
 		"tag":                       "token",
 		"telecom":                   "token",
@@ -537,11 +533,6 @@ func (s *FhirOrganizationAffiliation) PopulateAndExtractSearchParameters(resourc
 						 `)
 	if err == nil && serviceResult.String() != "undefined" {
 		s.Service = []byte(serviceResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Specialty
 	specialtyResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_patient.go
+++ b/backend/pkg/models/database/fhir_patient.go
@@ -174,9 +174,6 @@ type FhirPatient struct {
 	// Profiles this resource claims to conform to
 	// https://hl7.org/fhir/r4/search.html#reference
 	Profile datatypes.JSON `gorm:"column:profile;type:text;serializer:json" json:"profile,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Tags applied to this resource
 	// https://hl7.org/fhir/r4/search.html#token
 	Tag datatypes.JSON `gorm:"column:tag;type:text;serializer:json" json:"tag,omitempty"`
@@ -225,7 +222,6 @@ func (s *FhirPatient) GetSearchParameters() map[string]string {
 		"phone":               "token",
 		"phonetic":            "string",
 		"profile":             "reference",
-		"sourceUri":           "uri",
 		"tag":                 "token",
 		"telecom":             "token",
 		"text":                "string",
@@ -1261,11 +1257,6 @@ func (s *FhirPatient) PopulateAndExtractSearchParameters(resourceRaw json.RawMes
 						 `)
 	if err == nil && profileResult.String() != "undefined" {
 		s.Profile = []byte(profileResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Tag
 	tagResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_person.go
+++ b/backend/pkg/models/database/fhir_person.go
@@ -152,9 +152,6 @@ type FhirPerson struct {
 	// The Person links to this RelatedPerson
 	// https://hl7.org/fhir/r4/search.html#reference
 	Relatedperson datatypes.JSON `gorm:"column:relatedperson;type:text;serializer:json" json:"relatedperson,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Tags applied to this resource
 	// https://hl7.org/fhir/r4/search.html#token
 	Tag datatypes.JSON `gorm:"column:tag;type:text;serializer:json" json:"tag,omitempty"`
@@ -199,7 +196,6 @@ func (s *FhirPerson) GetSearchParameters() map[string]string {
 		"practitioner":      "reference",
 		"profile":           "reference",
 		"relatedperson":     "reference",
-		"sourceUri":         "uri",
 		"tag":               "token",
 		"telecom":           "token",
 		"text":              "string",
@@ -1024,11 +1020,6 @@ func (s *FhirPerson) PopulateAndExtractSearchParameters(resourceRaw json.RawMess
 						 `)
 	if err == nil && relatedpersonResult.String() != "undefined" {
 		s.Relatedperson = []byte(relatedpersonResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Tag
 	tagResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_practitioner.go
+++ b/backend/pkg/models/database/fhir_practitioner.go
@@ -153,9 +153,6 @@ type FhirPractitioner struct {
 	// Profiles this resource claims to conform to
 	// https://hl7.org/fhir/r4/search.html#reference
 	Profile datatypes.JSON `gorm:"column:profile;type:text;serializer:json" json:"profile,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Tags applied to this resource
 	// https://hl7.org/fhir/r4/search.html#token
 	Tag datatypes.JSON `gorm:"column:tag;type:text;serializer:json" json:"tag,omitempty"`
@@ -199,7 +196,6 @@ func (s *FhirPractitioner) GetSearchParameters() map[string]string {
 		"phone":             "token",
 		"phonetic":          "string",
 		"profile":           "reference",
-		"sourceUri":         "uri",
 		"tag":               "token",
 		"telecom":           "token",
 		"text":              "string",
@@ -1167,11 +1163,6 @@ func (s *FhirPractitioner) PopulateAndExtractSearchParameters(resourceRaw json.R
 						 `)
 	if err == nil && profileResult.String() != "undefined" {
 		s.Profile = []byte(profileResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Tag
 	tagResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_practitioner_role.go
+++ b/backend/pkg/models/database/fhir_practitioner_role.go
@@ -72,9 +72,6 @@ type FhirPractitionerRole struct {
 	// The list of healthcare services that this worker provides for this role's Organization/Location(s)
 	// https://hl7.org/fhir/r4/search.html#reference
 	Service datatypes.JSON `gorm:"column:service;type:text;serializer:json" json:"service,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// The practitioner has this specialty at an organization
 	// https://hl7.org/fhir/r4/search.html#token
 	Specialty datatypes.JSON `gorm:"column:specialty;type:text;serializer:json" json:"specialty,omitempty"`
@@ -116,7 +113,6 @@ func (s *FhirPractitionerRole) GetSearchParameters() map[string]string {
 		"profile":      "reference",
 		"role":         "token",
 		"service":      "reference",
-		"sourceUri":    "uri",
 		"specialty":    "token",
 		"tag":          "token",
 		"telecom":      "token",
@@ -543,11 +539,6 @@ func (s *FhirPractitionerRole) PopulateAndExtractSearchParameters(resourceRaw js
 						 `)
 	if err == nil && serviceResult.String() != "undefined" {
 		s.Service = []byte(serviceResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Specialty
 	specialtyResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_procedure.go
+++ b/backend/pkg/models/database/fhir_procedure.go
@@ -147,9 +147,6 @@ type FhirProcedure struct {
 	// The justification that the procedure was performed
 	// https://hl7.org/fhir/r4/search.html#reference
 	ReasonReference datatypes.JSON `gorm:"column:reasonReference;type:text;serializer:json" json:"reasonReference,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -185,7 +182,6 @@ func (s *FhirProcedure) GetSearchParameters() map[string]string {
 		"profile":               "reference",
 		"reasonCode":            "token",
 		"reasonReference":       "reference",
-		"sourceUri":             "uri",
 		"status":                "token",
 		"subject":               "reference",
 		"tag":                   "token",
@@ -598,11 +594,6 @@ func (s *FhirProcedure) PopulateAndExtractSearchParameters(resourceRaw json.RawM
 						 `)
 	if err == nil && reasonReferenceResult.String() != "undefined" {
 		s.ReasonReference = []byte(reasonReferenceResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_provenance.go
+++ b/backend/pkg/models/database/fhir_provenance.go
@@ -44,9 +44,6 @@ type FhirProvenance struct {
 	// Indication of the reason the entity signed the object(s)
 	// https://hl7.org/fhir/r4/search.html#token
 	SignatureType datatypes.JSON `gorm:"column:signatureType;type:text;serializer:json" json:"signatureType,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Tags applied to this resource
 	// https://hl7.org/fhir/r4/search.html#token
 	Tag datatypes.JSON `gorm:"column:tag;type:text;serializer:json" json:"tag,omitempty"`
@@ -76,7 +73,6 @@ func (s *FhirProvenance) GetSearchParameters() map[string]string {
 		"profile":       "reference",
 		"recorded":      "date",
 		"signatureType": "token",
-		"sourceUri":     "uri",
 		"tag":           "token",
 		"target":        "reference",
 		"text":          "string",
@@ -381,11 +377,6 @@ func (s *FhirProvenance) PopulateAndExtractSearchParameters(resourceRaw json.Raw
 						 `)
 	if err == nil && signatureTypeResult.String() != "undefined" {
 		s.SignatureType = []byte(signatureTypeResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Tag
 	tagResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_questionnaire.go
+++ b/backend/pkg/models/database/fhir_questionnaire.go
@@ -59,9 +59,6 @@ type FhirQuestionnaire struct {
 	// Name of the publisher of the questionnaire
 	// https://hl7.org/fhir/r4/search.html#string
 	Publisher datatypes.JSON `gorm:"column:publisher;type:text;serializer:json" json:"publisher,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// The current status of the questionnaire
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -105,7 +102,6 @@ func (s *FhirQuestionnaire) GetSearchParameters() map[string]string {
 		"name":            "string",
 		"profile":         "reference",
 		"publisher":       "string",
-		"sourceUri":       "uri",
 		"status":          "token",
 		"subjectType":     "token",
 		"tag":             "token",
@@ -665,11 +661,6 @@ func (s *FhirQuestionnaire) PopulateAndExtractSearchParameters(resourceRaw json.
 						 `)
 	if err == nil && publisherResult.String() != "undefined" {
 		s.Publisher = []byte(publisherResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_questionnaire_response.go
+++ b/backend/pkg/models/database/fhir_questionnaire_response.go
@@ -47,9 +47,6 @@ type FhirQuestionnaireResponse struct {
 	// The individual providing the information reflected in the questionnaire respose
 	// https://hl7.org/fhir/r4/search.html#reference
 	Source datatypes.JSON `gorm:"column:source;type:text;serializer:json" json:"source,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// The status of the questionnaire response
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -80,7 +77,6 @@ func (s *FhirQuestionnaireResponse) GetSearchParameters() map[string]string {
 		"profile":       "reference",
 		"questionnaire": "reference",
 		"source":        "reference",
-		"sourceUri":     "uri",
 		"status":        "token",
 		"subject":       "reference",
 		"tag":           "token",
@@ -333,11 +329,6 @@ func (s *FhirQuestionnaireResponse) PopulateAndExtractSearchParameters(resourceR
 						 `)
 	if err == nil && sourceResult.String() != "undefined" {
 		s.Source = []byte(sourceResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_related_person.go
+++ b/backend/pkg/models/database/fhir_related_person.go
@@ -146,9 +146,6 @@ type FhirRelatedPerson struct {
 	// The relationship between the patient and the relatedperson
 	// https://hl7.org/fhir/r4/search.html#token
 	Relationship datatypes.JSON `gorm:"column:relationship;type:text;serializer:json" json:"relationship,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Tags applied to this resource
 	// https://hl7.org/fhir/r4/search.html#token
 	Tag datatypes.JSON `gorm:"column:tag;type:text;serializer:json" json:"tag,omitempty"`
@@ -191,7 +188,6 @@ func (s *FhirRelatedPerson) GetSearchParameters() map[string]string {
 		"phonetic":          "string",
 		"profile":           "reference",
 		"relationship":      "token",
-		"sourceUri":         "uri",
 		"tag":               "token",
 		"telecom":           "token",
 		"text":              "string",
@@ -1054,11 +1050,6 @@ func (s *FhirRelatedPerson) PopulateAndExtractSearchParameters(resourceRaw json.
 						 `)
 	if err == nil && relationshipResult.String() != "undefined" {
 		s.Relationship = []byte(relationshipResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Tag
 	tagResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_schedule.go
+++ b/backend/pkg/models/database/fhir_schedule.go
@@ -41,9 +41,6 @@ type FhirSchedule struct {
 	// The type of appointments that can be booked into associated slot(s)
 	// https://hl7.org/fhir/r4/search.html#token
 	ServiceType datatypes.JSON `gorm:"column:serviceType;type:text;serializer:json" json:"serviceType,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Type of specialty needed
 	// https://hl7.org/fhir/r4/search.html#token
 	Specialty datatypes.JSON `gorm:"column:specialty;type:text;serializer:json" json:"specialty,omitempty"`
@@ -69,7 +66,6 @@ func (s *FhirSchedule) GetSearchParameters() map[string]string {
 		"profile":         "reference",
 		"serviceCategory": "token",
 		"serviceType":     "token",
-		"sourceUri":       "uri",
 		"specialty":       "token",
 		"tag":             "token",
 		"text":            "string",
@@ -392,11 +388,6 @@ func (s *FhirSchedule) PopulateAndExtractSearchParameters(resourceRaw json.RawMe
 						 `)
 	if err == nil && serviceTypeResult.String() != "undefined" {
 		s.ServiceType = []byte(serviceTypeResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Specialty
 	specialtyResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_service_request.go
+++ b/backend/pkg/models/database/fhir_service_request.go
@@ -139,9 +139,6 @@ type FhirServiceRequest struct {
 	// Composite Request ID
 	// https://hl7.org/fhir/r4/search.html#token
 	Requisition datatypes.JSON `gorm:"column:requisition;type:text;serializer:json" json:"requisition,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// Specimen to be tested
 	// https://hl7.org/fhir/r4/search.html#reference
 	Specimen datatypes.JSON `gorm:"column:specimen;type:text;serializer:json" json:"specimen,omitempty"`
@@ -184,7 +181,6 @@ func (s *FhirServiceRequest) GetSearchParameters() map[string]string {
 		"replaces":              "reference",
 		"requester":             "reference",
 		"requisition":           "token",
-		"sourceUri":             "uri",
 		"specimen":              "reference",
 		"status":                "token",
 		"subject":               "reference",
@@ -785,11 +781,6 @@ func (s *FhirServiceRequest) PopulateAndExtractSearchParameters(resourceRaw json
 						 `)
 	if err == nil && requisitionResult.String() != "undefined" {
 		s.Requisition = []byte(requisitionResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Specimen
 	specimenResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_slot.go
+++ b/backend/pkg/models/database/fhir_slot.go
@@ -38,9 +38,6 @@ type FhirSlot struct {
 	// The type of appointments that can be booked into the slot
 	// https://hl7.org/fhir/r4/search.html#token
 	ServiceType datatypes.JSON `gorm:"column:serviceType;type:text;serializer:json" json:"serviceType,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// The specialty of a practitioner that would be required to perform the service requested in this appointment
 	// https://hl7.org/fhir/r4/search.html#token
 	Specialty datatypes.JSON `gorm:"column:specialty;type:text;serializer:json" json:"specialty,omitempty"`
@@ -71,7 +68,6 @@ func (s *FhirSlot) GetSearchParameters() map[string]string {
 		"schedule":        "reference",
 		"serviceCategory": "token",
 		"serviceType":     "token",
-		"sourceUri":       "uri",
 		"specialty":       "token",
 		"start":           "date",
 		"status":          "token",
@@ -383,11 +379,6 @@ func (s *FhirSlot) PopulateAndExtractSearchParameters(resourceRaw json.RawMessag
 						 `)
 	if err == nil && serviceTypeResult.String() != "undefined" {
 		s.ServiceType = []byte(serviceTypeResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Specialty
 	specialtyResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_specimen.go
+++ b/backend/pkg/models/database/fhir_specimen.go
@@ -47,9 +47,6 @@ type FhirSpecimen struct {
 	// Profiles this resource claims to conform to
 	// https://hl7.org/fhir/r4/search.html#reference
 	Profile datatypes.JSON `gorm:"column:profile;type:text;serializer:json" json:"profile,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// available | unavailable | unsatisfactory | entered-in-error
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -80,7 +77,6 @@ func (s *FhirSpecimen) GetSearchParameters() map[string]string {
 		"lastUpdated": "date",
 		"parent":      "reference",
 		"profile":     "reference",
-		"sourceUri":   "uri",
 		"status":      "token",
 		"subject":     "reference",
 		"tag":         "token",
@@ -465,11 +461,6 @@ func (s *FhirSpecimen) PopulateAndExtractSearchParameters(resourceRaw json.RawMe
 						 `)
 	if err == nil && profileResult.String() != "undefined" {
 		s.Profile = []byte(profileResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/fhir_vision_prescription.go
+++ b/backend/pkg/models/database/fhir_vision_prescription.go
@@ -83,9 +83,6 @@ type FhirVisionPrescription struct {
 	// Profiles this resource claims to conform to
 	// https://hl7.org/fhir/r4/search.html#reference
 	Profile datatypes.JSON `gorm:"column:profile;type:text;serializer:json" json:"profile,omitempty"`
-	// Identifies where the resource comes from
-	// https://hl7.org/fhir/r4/search.html#uri
-	SourceUri string `gorm:"column:sourceUri;type:text" json:"sourceUri,omitempty"`
 	// The status of the vision prescription
 	// https://hl7.org/fhir/r4/search.html#token
 	Status datatypes.JSON `gorm:"column:status;type:text;serializer:json" json:"status,omitempty"`
@@ -109,7 +106,6 @@ func (s *FhirVisionPrescription) GetSearchParameters() map[string]string {
 		"lastUpdated": "date",
 		"prescriber":  "reference",
 		"profile":     "reference",
-		"sourceUri":   "uri",
 		"status":      "token",
 		"tag":         "token",
 		"text":        "string",
@@ -305,11 +301,6 @@ func (s *FhirVisionPrescription) PopulateAndExtractSearchParameters(resourceRaw 
 						 `)
 	if err == nil && profileResult.String() != "undefined" {
 		s.Profile = []byte(profileResult.String())
-	}
-	// extracting SourceUri
-	sourceUriResult, err := vm.RunString("window.fhirpath.evaluate(fhirResource, 'meta.source')[0]")
-	if err == nil && sourceUriResult.String() != "undefined" {
-		s.SourceUri = sourceUriResult.String()
 	}
 	// extracting Status
 	statusResult, err := vm.RunString(` 

--- a/backend/pkg/models/database/generate.go
+++ b/backend/pkg/models/database/generate.go
@@ -123,11 +123,6 @@ func main() {
 			Description:        "Profiles this resource claims to conform to",
 			FHIRPathExpression: "Resource.meta.profile",
 		}
-		fieldMap["SourceUri"] = DBField{
-			FieldType:          "uri",
-			Description:        "Identifies where the resource comes from",
-			FHIRPathExpression: "Resource.meta.source",
-		}
 		fieldMap["Tag"] = DBField{
 			FieldType:          "token",
 			Description:        "Tags applied to this resource",

--- a/backend/pkg/models/database/interface.go
+++ b/backend/pkg/models/database/interface.go
@@ -13,6 +13,7 @@ type IFhirResourceModel interface {
 	SetResourceRaw(resourceRaw datatypes.JSON)
 	SetSortTitle(sortTitle *string)
 	SetSortDate(sortDate *time.Time)
+	SetSourceUri(sourceUri *string)
 	GetSearchParameters() map[string]string
 	PopulateAndExtractSearchParameters(rawResource json.RawMessage) error
 }

--- a/backend/pkg/models/query_resource_test.go
+++ b/backend/pkg/models/query_resource_test.go
@@ -19,9 +19,9 @@ func TestQueryResource_Validate(t *testing.T) {
 		{QueryResource{From: "test", Aggregations: &QueryResourceAggregations{CountBy: "test", OrderBy: "test"}}, "cannot use 'count_by' and 'order_by' together", true},
 		{QueryResource{From: "test", Aggregations: &QueryResourceAggregations{}}, "aggregations must have at least one of 'count_by', 'group_by', or 'order_by'", true},
 		{QueryResource{From: "test", Aggregations: &QueryResourceAggregations{CountBy: "test:property"}}, "", false},
-		{QueryResource{From: "test", Aggregations: &QueryResourceAggregations{CountBy: "test:property as HELLO"}}, "count_by cannot have spaces", true},
-		{QueryResource{From: "test", Aggregations: &QueryResourceAggregations{GroupBy: "test:property as HELLO"}}, "group_by cannot have spaces", true},
-		{QueryResource{From: "test", Aggregations: &QueryResourceAggregations{OrderBy: "test:property as HELLO"}}, "order_by cannot have spaces", true},
+		{QueryResource{From: "test", Aggregations: &QueryResourceAggregations{CountBy: "test:property as HELLO"}}, "count_by cannot have spaces (or aliases)", true},
+		{QueryResource{From: "test", Aggregations: &QueryResourceAggregations{GroupBy: "test:property as HELLO"}}, "group_by cannot have spaces (or aliases)", true},
+		{QueryResource{From: "test", Aggregations: &QueryResourceAggregations{OrderBy: "test:property as HELLO"}}, "order_by cannot have spaces (or aliases)", true},
 	}
 
 	//test && assert

--- a/backend/pkg/models/resource_base.go
+++ b/backend/pkg/models/resource_base.go
@@ -10,6 +10,7 @@ type ResourceBase struct {
 
 	SortDate  *time.Time `json:"sort_date" gorm:"sort_date"`
 	SortTitle *string    `json:"sort_title" gorm:"sort_title"`
+	SourceUri *string    `json:"source_uri" gorm:"source_uri"`
 
 	// The raw resource content in JSON format
 	ResourceRaw datatypes.JSON `gorm:"column:resource_raw;type:text;serializer:json" json:"resource_raw,omitempty"`
@@ -31,4 +32,8 @@ func (s *ResourceBase) SetSortDate(sortDate *time.Time) {
 
 func (s *ResourceBase) SetResourceRaw(resourceRaw datatypes.JSON) {
 	s.ResourceRaw = resourceRaw
+}
+
+func (s *ResourceBase) SetSourceUri(sourceUri *string) {
+	s.SourceUri = sourceUri
 }

--- a/backend/pkg/web/handler/unsafe.go
+++ b/backend/pkg/web/handler/unsafe.go
@@ -75,7 +75,7 @@ func UnsafeRequestSource(c *gin.Context) {
 	//make sure we include all query string parameters with the raw request.
 	parsedUrl.RawQuery = c.Request.URL.Query().Encode()
 
-	err = client.GetRequest(parsedUrl.String(), &resp)
+	_, err = client.GetRequest(parsedUrl.String(), &resp)
 	if err != nil {
 		logger.Errorf("Error making raw request, %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": err.Error(), "data": resp})

--- a/frontend/src/app/components/fhir/resources/diagnostic-report/diagnostic-report.component.html
+++ b/frontend/src/app/components/fhir/resources/diagnostic-report/diagnostic-report.component.html
@@ -14,6 +14,10 @@
   <div #collapse="ngbCollapse" [(ngbCollapse)]="isCollapsed" class="card-body">
     <p class="az-content-text mg-b-20" *ngIf="!(resourceCode && resourceCodeSystem); else lookupCode">An action that is or was performed on or for a patient, practitioner, device, organization, or location. For example, this can be a physical intervention on a patient like an operation, or less invasive like long term services, counseling, or hypnotherapy.</p>
     <fhir-ui-table [displayModel]="displayModel" [tableData]="tableData"></fhir-ui-table>
+
+    <div *ngIf="!showDetails">
+      <fhir-binary *ngFor="let attachmentModel of displayModel.presented_form" [attachmentModel]="attachmentModel" [attachmentSourceId]="displayModel?.source_id" ></fhir-binary>
+    </div>
   </div>
   <div *ngIf="showDetails" class="card-footer">
     <a class="float-right" routerLink="/explore/{{displayModel?.source_id}}/resource/{{displayModel?.source_resource_id}}">details</a>

--- a/frontend/src/lib/models/resources/diagnostic-report-model.ts
+++ b/frontend/src/lib/models/resources/diagnostic-report-model.ts
@@ -5,6 +5,7 @@ import {ReferenceModel} from '../datatypes/reference-model';
 import {CodingModel} from '../datatypes/coding-model';
 import {FastenDisplayModel} from '../fasten/fasten-display-model';
 import {FastenOptions} from '../fasten/fasten-options';
+import {AttachmentModel} from '../datatypes/attachment-model';
 
 export class DiagnosticReportModel extends FastenDisplayModel {
   code: CodableConceptModel | undefined
@@ -19,6 +20,7 @@ export class DiagnosticReportModel extends FastenDisplayModel {
   conclusion: string | undefined
   performer: ReferenceModel | undefined
   issued: string | undefined
+  presented_form: AttachmentModel[] | undefined
 
   constructor(fhirResource: any, fhirVersion?: fhirVersions, fastenOptions?: FastenOptions) {
     super(fastenOptions)
@@ -39,6 +41,7 @@ export class DiagnosticReportModel extends FastenDisplayModel {
     this.has_category_coding = Array.isArray(this.category_coding);
     this.conclusion = _.get(fhirResource, 'conclusion');
     this.issued = _.get(fhirResource, 'issued');
+
   };
 
   dstu2DTO(fhirResource:any){
@@ -58,6 +61,10 @@ export class DiagnosticReportModel extends FastenDisplayModel {
     this.has_performer = !!this.performer;
     this.category_coding = _.get(fhirResource, 'category.coding');
     this.has_category_coding = Array.isArray(this.category_coding);
+
+    this.presented_form = _.get(fhirResource, 'presentedForm', []).map((attachment: any) => {
+      return new AttachmentModel(attachment);
+    })
   };
 
   resourceDTO(fhirResource:any, fhirVersion: fhirVersions){

--- a/frontend/src/lib/utils/resource_related_display_model.ts
+++ b/frontend/src/lib/utils/resource_related_display_model.ts
@@ -46,5 +46,5 @@ export function RecResourceRelatedDisplayModel(resource: ResourceFhir, resources
 }
 
 export function GenResourceId(relatedResource: ResourceFhir): string {
-  return `/source/${relatedResource?.source_id}/resource/${relatedResource?.source_resource_type}/${relatedResource?.source_resource_id}`
+  return `/explore/${relatedResource?.source_id}/resource/${relatedResource?.source_resource_type}/${relatedResource?.source_resource_id}`
 }

--- a/go.mod
+++ b/go.mod
@@ -107,4 +107,4 @@ require (
 	modernc.org/sqlite v1.19.1 // indirect
 )
 
-replace github.com/fastenhealth/fasten-sources => ../fasten-sources
+//replace github.com/fastenhealth/fasten-sources => ../fasten-sources

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dave/jennifer v1.6.1
 	github.com/dominikbraun/graph v0.15.0
 	github.com/dop251/goja v0.0.0-20230605162241-28ee0ee714f3
-	github.com/fastenhealth/fasten-sources v0.2.7
+	github.com/fastenhealth/fasten-sources v0.2.9
 	github.com/fastenhealth/gofhir-models v0.0.5
 	github.com/gin-gonic/gin v1.9.0
 	github.com/glebarez/sqlite v1.5.0
@@ -17,6 +17,7 @@ require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/lestrrat-go/jwx/v2 v2.0.11
 	github.com/philips-software/go-hsdp-api v0.81.0
+	github.com/samber/lo v1.35.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.8.4
@@ -78,7 +79,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/samber/lo v1.35.0 // indirect
 	github.com/seborama/govcr v4.5.0+incompatible // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e // indirect
@@ -107,4 +107,4 @@ require (
 	modernc.org/sqlite v1.19.1 // indirect
 )
 
-//replace github.com/fastenhealth/fasten-sources => ../fasten-sources
+replace github.com/fastenhealth/fasten-sources => ../fasten-sources

--- a/go.sum
+++ b/go.sum
@@ -191,6 +191,8 @@ github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
+github.com/fastenhealth/fasten-sources v0.2.9 h1:oUaUZ+0XO2Rbv6PNtgW5yPtCwdx61g810pBQhzKw68c=
+github.com/fastenhealth/fasten-sources v0.2.9/go.mod h1:KUtpp65GaKlpRvl5i8zWTVZlI1yJaUPkvGVqQVEC21w=
 github.com/fastenhealth/gofhir-models v0.0.5 h1:wU2Dz+/h9MzZCTRgkQzeq5l0EFuMI6C5xgCbKislFpg=
 github.com/fastenhealth/gofhir-models v0.0.5/go.mod h1:xB8ikGxu3bUq2b1JYV+CZpHqBaLXpOizFR0eFBCunis=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,6 @@ github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
-github.com/fastenhealth/fasten-sources v0.2.7 h1:g4blrTMJK/QfJI5X6VjvDk6P475kxgx9EBxQWuXmkoc=
-github.com/fastenhealth/fasten-sources v0.2.7/go.mod h1:B7pVQcwLuL+rgjSHwlu3p0CySyHN262BkfbYMKVKXTk=
 github.com/fastenhealth/gofhir-models v0.0.5 h1:wU2Dz+/h9MzZCTRgkQzeq5l0EFuMI6C5xgCbKislFpg=
 github.com/fastenhealth/gofhir-models v0.0.5/go.mod h1:xB8ikGxu3bUq2b1JYV+CZpHqBaLXpOizFR0eFBCunis=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=


### PR DESCRIPTION
- [feat] update fasten-sources version to v0.2.9
	- fixes #225	 	
	- Some providers do not correctly return wrapped Binary resources, instead returning raw PDF's which are skipped during sync. Added logic to handle and wrap these resources ourselves. 
	- better parsing of date/datetime values in FHIR Resources (previously only datetime was supported)
- make sure that the Binary component in the UI can query against the ResourceType+ResourceId and the SourceURI
	- fixes #232