### PR TITLE
split frontend routing config from backend config.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ build-frontend-prod: dep-frontend
 
 .PHONY: build-frontend-desktop
 build-frontend-desktop: dep-frontend
-	cd frontend && yarn build -- -c desktop
+	cd frontend && yarn build -- -c desktop_sandbox
 
 
 .PHONY: test-frontend

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -127,11 +127,11 @@
                 }
               ]
             },
-            "desktop": {
+            "desktop_sandbox": {
               "fileReplacements": [
                 {
                   "replace": "src/environments/environment.ts",
-                  "with": "src/environments/environment.desktop.ts"
+                  "with": "src/environments/environment.desktop_sandbox.ts"
                 }
               ],
               "optimization": true,
@@ -171,8 +171,8 @@
             "cloud_sandbox": {
               "browserTarget": "fastenhealth:build:cloud_sandbox"
             },
-            "desktop": {
-              "browserTarget": "fastenhealth:build:desktop"
+            "desktop_sandbox": {
+              "browserTarget": "fastenhealth:build:desktop_sandbox"
             }
           }
         },

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -14,6 +14,7 @@ import {MedicalHistoryComponent} from './pages/medical-history/medical-history.c
 import {ReportLabsComponent} from './pages/report-labs/report-labs.component';
 import {ResourceCreatorComponent} from './pages/resource-creator/resource-creator.component';
 import {ExploreComponent} from './pages/explore/explore.component';
+import {environment} from '../environments/environment';
 
 const routes: Routes = [
 
@@ -50,7 +51,7 @@ const routes: Routes = [
 
 @NgModule({
   imports: [
-    RouterModule.forRoot(routes),
+    RouterModule.forRoot(routes,  {useHash: environment.environment_desktop}),
     CommonModule,
     BrowserModule,
   ],

--- a/frontend/src/app/components/medical-sources-connected/medical-sources-connected.component.ts
+++ b/frontend/src/app/components/medical-sources-connected/medical-sources-connected.component.ts
@@ -79,7 +79,8 @@ export class MedicalSourcesConnectedComponent implements OnInit {
 
         //get required parameters from the URI and local storage
         const callbackUrlParts = new URL(window.location.href)
-        const fragmentParams = new URLSearchParams(callbackUrlParts.hash.substring(1))
+        //in desktop mode, we're using fragment routing, and the callback params are in the fragment.
+        const fragmentParams = new URLSearchParams(callbackUrlParts.hash.split('?')?.[1] || '')
         const callbackCode = callbackUrlParts.searchParams.get("code") || fragmentParams.get("code")
         const callbackState = callbackUrlParts.searchParams.get("state") || fragmentParams.get("state")
         const callbackError = callbackUrlParts.searchParams.get("error") || fragmentParams.get("error")

--- a/frontend/src/app/services/lighthouse.service.ts
+++ b/frontend/src/app/services/lighthouse.service.ts
@@ -145,14 +145,21 @@ export class LighthouseService {
    */
   redirectWithOriginAndDestination(destUrl: string, sourceType: string, callbackUri: string): void {
     const originUrlParts = new URL(window.location.href)
-    originUrlParts.hash = "" //reset hash in-case its present.
-    originUrlParts.pathname = this.pathJoin([originUrlParts.pathname, `callback/${sourceType}`])
 
+    if(environment.environment_desktop){
+      //hash based routing
+      originUrlParts.hash = this.pathJoin([originUrlParts.hash, `callback/${sourceType}`])
+    } else {
+      //path based routing
+      originUrlParts.hash = "" //reset hash in-case its present.
+      originUrlParts.pathname = this.pathJoin([originUrlParts.pathname, `callback/${sourceType}`])
+    }
 
     const redirectUrlParts = new URL(callbackUri.replace("/callback/", "/redirect/"));
     const redirectParams = new URLSearchParams()
     redirectParams.set("origin_url", originUrlParts.toString())
     redirectParams.set("dest_url", destUrl)
+    redirectParams.set("desktop_mode", environment.environment_desktop ? "true" : "false")
     redirectUrlParts.search = redirectParams.toString()
     console.log(redirectUrlParts.toString());
 

--- a/frontend/src/environments/environment.cloud_sandbox.ts
+++ b/frontend/src/environments/environment.cloud_sandbox.ts
@@ -1,6 +1,7 @@
 export const environment = {
   production: true,
   environment_cloud: true,
+  environment_desktop: false,
   environment_name: "sandbox",
   lighthouse_api_endpoint_base: 'https://lighthouse.fastenhealth.com/sandbox',
 

--- a/frontend/src/environments/environment.desktop_sandbox.ts
+++ b/frontend/src/environments/environment.desktop_sandbox.ts
@@ -1,9 +1,10 @@
 export const environment = {
   production: true,
   environment_cloud: false,
-  environment_name: "desktop",
+  environment_desktop: true,
+  environment_name: "desktop_sandbox",
 
-  lighthouse_api_endpoint_base: 'https://lighthouse.fastenhealth.com/v1',
+  lighthouse_api_endpoint_base: 'https://lighthouse.fastenhealth.com/sandbox',
 
 
   //used to specify the api server that we're going to use (can be relative or absolute). Must not have trailing slash

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,6 +1,7 @@
 export const environment = {
   production: true,
   environment_cloud: false,
+  environment_desktop: false,
   environment_name: "prod",
 
   lighthouse_api_endpoint_base: 'https://lighthouse.fastenhealth.com/v1',

--- a/frontend/src/environments/environment.sandbox.ts
+++ b/frontend/src/environments/environment.sandbox.ts
@@ -5,6 +5,7 @@
 export const environment = {
   production: true,
   environment_cloud: false,
+  environment_desktop: false,
   environment_name: "sandbox",
 
   lighthouse_api_endpoint_base: 'https://lighthouse.fastenhealth.com/sandbox',

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -9,6 +9,9 @@ export const environment = {
   // is the application running in the cloud? (enables 3rd party IdP's and token based couchdb authentication)
   environment_cloud: false,
 
+  // is the application running in a desktop environment (Wails). If so we will use hash based routing
+  environment_desktop: false,
+
   // the environment name, `sandbox`, `prod`, `beta`
   environment_name: "sandbox",
 


### PR DESCRIPTION
Added method to use embedded frontend routing.
rename desktop config to desktop_sandbox config.

adding desktop_mode (used for Wails Desktop app + hash based routing) make sure all `window.location` parsing works correctly with desktop_mode