### PR TITLE
update FhirPatient unit tests for most fields

### DIFF
--- a/backend/pkg/models/database/fhir_patient_test.go
+++ b/backend/pkg/models/database/fhir_patient_test.go
@@ -70,6 +70,46 @@ func TestFhirPatient_ExtractSearchParameters(t *testing.T) {
 		},
 	}, testIdentifier)
 
+	var testGender []interface{}
+	err = json.Unmarshal(json.RawMessage(patientModel.Gender), &testGender)
+	require.NoError(t, err)
+	require.Equal(t, []interface{}{
+		map[string]interface{}{"code": "male"},
+	}, testGender)
+	
+	// To Do: Fix the Goja query issues for handling the deceasedBoolean field and them uncomment this unit test
+	// var testDeceased []interface{}
+	// err = json.Unmarshal(json.RawMessage(patientModel.Deceased), &testDeceased)
+	// require.NoError(t, err)
+	// require.Equal(t, []interface{}{
+	// 	map[string]interface{}{"code": true},
+	// }, testDeceased)
+
+	var testfamily []string
+	err = json.Unmarshal(json.RawMessage(patientModel.Family), &testfamily)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"Chalmers", "Windsor",
+	}, testfamily)
+
+	var testPhonetic []string
+	err = json.Unmarshal(json.RawMessage(patientModel.Phonetic), &testPhonetic)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"Peter James Chalmers","Jim", "Peter James Windsor",
+	}, testPhonetic)
+
+	var testOrganisation []interface{}
+	err = json.Unmarshal(json.RawMessage(patientModel.Organization), &testOrganisation)
+	require.NoError(t, err)
+	require.Equal(t, []interface{}{
+		map[string]interface{}{
+			"reference": "Organization/1",
+			"__path__": "Patient.managingOrganization",
+		},
+	}, testOrganisation)
+
+
 	require.Equal(t, time.Date(1974, 12, 25, 0, 0, 0, 0, time.UTC), *patientModel.Birthdate)
 
 }

--- a/backend/pkg/models/database/fhir_patient_test.go
+++ b/backend/pkg/models/database/fhir_patient_test.go
@@ -77,7 +77,7 @@ func TestFhirPatient_ExtractSearchParameters(t *testing.T) {
 		map[string]interface{}{"code": "male"},
 	}, testGender)
 	
-	// To Do: Fix the Goja query issues for handling the deceasedBoolean field and them uncomment this unit test
+	// TODO: Fix the Goja query issues for handling the deceasedBoolean field and them uncomment this unit test
 	// var testDeceased []interface{}
 	// err = json.Unmarshal(json.RawMessage(patientModel.Deceased), &testDeceased)
 	// require.NoError(t, err)

--- a/frontend/src/lib/fixtures/r4/resources/patient/example1.json
+++ b/frontend/src/lib/fixtures/r4/resources/patient/example1.json
@@ -81,7 +81,7 @@
       }
     ]
   },
-  "deceasedBoolean": false,
+  "deceasedBoolean": true,
   "address": [
     {
       "use": "home",


### PR DESCRIPTION
Added unit testing for the untested fields in fhir_patient.go. Only deceasedBoolean left to test now. Added To Do for the Goja parsing issue.
Changed the deceasedBoolean field in example1.json to true, as False (being default) does not show the correct testing behavior.