### PR TITLE
Fix date display

### DIFF
--- a/frontend/src/app/widgets/patient-vitals-widget/patient-vitals-widget.component.ts
+++ b/frontend/src/app/widgets/patient-vitals-widget/patient-vitals-widget.component.ts
@@ -88,8 +88,12 @@ export class PatientVitalsWidgetComponent extends DashboardWidgetComponent imple
       if(!this.name && _.get(patient, 'name[0].family') && _.get(patient, 'name[0].given[0]')){
         this.name = `${_.get(patient, 'name[0].given[0]')} ${_.get(patient, 'name[0].family')}`
       }
-      if(!this.age && _.get(patient, 'birthDate')){
-        this.age = `${moment().diff(moment(_.get(patient, 'birthDate')), 'years')} years`
+      const birthDate = _.get(patient, 'birthDate');
+      if(!this.age && birthDate){
+        const birthDateString = Array.isArray(birthDate) ? birthDate[0] : birthDate;
+        const birthDateMoment = moment(birthDateString);
+        this.age = `${moment().diff(birthDateMoment, 'years')} years`; // moment.diff rounds down
+        console.log(this.age);
       }
       if(!this.gender && _.get(patient, 'gender[0]')){
         this.gender = _.get(patient, 'gender[0]')
@@ -190,6 +194,8 @@ export class PatientVitalsWidgetComponent extends DashboardWidgetComponent imple
     for(let key in vitalSignCodeLookup){
       this.vitalSigns.push(vitalSignCodeLookup[key])
     }
+
+    console.log(this);
 
     console.log("PRINTING DETECTED PATIENT DATA", this.name, this.age, this.gender, vitalSignCodeLookup, this.vitalSigns)
   }

--- a/frontend/src/app/widgets/patient-vitals-widget/patient-vitals-widget.component.ts
+++ b/frontend/src/app/widgets/patient-vitals-widget/patient-vitals-widget.component.ts
@@ -82,7 +82,7 @@ export class PatientVitalsWidgetComponent extends DashboardWidgetComponent imple
       return
     }
 
-    //process Patient objecst
+    //process Patient objects
     let sortedPatients = _.sortBy(queryResults?.[1], ['birthDate'])
     for(let patient of sortedPatients){
       if(!this.name && _.get(patient, 'name[0].family') && _.get(patient, 'name[0].given[0]')){
@@ -93,7 +93,6 @@ export class PatientVitalsWidgetComponent extends DashboardWidgetComponent imple
         const birthDateString = Array.isArray(birthDate) ? birthDate[0] : birthDate;
         const birthDateMoment = moment(birthDateString);
         this.age = `${moment().diff(birthDateMoment, 'years')} years`; // moment.diff rounds down
-        console.log(this.age);
       }
       if(!this.gender && _.get(patient, 'gender[0]')){
         this.gender = _.get(patient, 'gender[0]')

--- a/frontend/src/app/widgets/patient-vitals-widget/patient-vitals-widget.component.ts
+++ b/frontend/src/app/widgets/patient-vitals-widget/patient-vitals-widget.component.ts
@@ -194,8 +194,6 @@ export class PatientVitalsWidgetComponent extends DashboardWidgetComponent imple
       this.vitalSigns.push(vitalSignCodeLookup[key])
     }
 
-    console.log(this);
-
     console.log("PRINTING DETECTED PATIENT DATA", this.name, this.age, this.gender, vitalSignCodeLookup, this.vitalSigns)
   }
 


### PR DESCRIPTION
### Issue

On the homepage dashboard to the right, where it says [Patient Name] | [Age] years | Gender:
- A patient birthdate of, for example, "2000-08-01" will incorrectly return **24 years** on the homepage
- It should return the correct age **23 years** (since the birthday has not passed yet this year). 

I believe this was an issue because it was somehow parsing the year but not the month and day of the `birthDate`, at least when there are multiple patient objects in the DB. 

### Fix
Check if it is an array before calculating age. 

### Other considerations
It is not an issue in `SourceDetailComponent`'s function `getPatientAge()`, because that uses a flattener helper method `getPath()`. I can centralize this logic instead in the PR, if you'd like. 