### PR TITLE
Prevent possible endless loop with image fallback

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -1,6 +1,7 @@
 import type { StorybookConfig } from "@storybook/angular";
 const config: StorybookConfig = {
   stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
+  staticDirs: [{ from: '../src/assets', to: '/assets' }],
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",

--- a/frontend/src/app/directives/image-fallback.directive.ts
+++ b/frontend/src/app/directives/image-fallback.directive.ts
@@ -1,5 +1,7 @@
 import {Directive, ElementRef, HostListener, Input} from '@angular/core';
 
+const DEFAULT_IMAGE_FALLBACK_PATH: string = '/assets/images/no-image.svg';
+
 @Directive({
   selector: 'img[imageFallback]'
 })
@@ -10,7 +12,22 @@ export class ImageFallbackDirective {
 
   @HostListener('error')
   loadFallbackOnError() {
-    this.elementRef.nativeElement.src = this.imageFallback || 'assets/images/no-image.svg';
+    // Check to see if we have already tried to load the fallback image.
+    // Avoids endless loop if for some reason fallback image is missing. Just accept the broken image.
+    if (this.path(this.elementRef.nativeElement.src) == this.path(this.fallbackSrc())) {
+      return;
+    }
+
+    this.elementRef.nativeElement.src = this.fallbackSrc();
+  }
+
+  private fallbackSrc(): string {
+    return this.imageFallback || DEFAULT_IMAGE_FALLBACK_PATH;
+  }
+
+  private path(urlString: string): string {
+    // remove http(s) and domain
+    return urlString.replace(/^https?:\/\/[^\/]*/, '');
   }
 
 }


### PR DESCRIPTION
# Description

So I noticed that in the Storybook upload off of main that the medical sources card component is erroring out and it isn't able to generate snapshots. When I click into it on the website it seems like there are two problems: 
1) The assets aren't getting added to the storybook upload causing the fallback image not to be found. 
2) The image fallback directive is trapped in an endless loop looking for the fallback image.

I found some [docs](https://storybook.js.org/docs/configure/images-and-assets#serving-static-files-via-storybook-configuration) saying that serving static assets via Storybook configuration is recommended so I've tried adding that configuration. I'm not sure if it will work, or if this is what is causing the component error making the build fail, but I figured it was worth a shot.

As for the second issue, I've updated the image fallback code so that it shouldn't endlessly loop in the case that even the fallback image fails. Basically it just checks to see if the failed image was the fallback image and if it was, return rather than resetting src which triggers another attempt and error and so on.

## Changes

- add config to storybook for serving static assets
- only attempt to load fallback image if we haven't already tried to load it