### PR TITLE
Parse lab values that include a range

### DIFF
--- a/frontend/src/app/components/fhir-card/common/observation-bar-chart/observation-bar-chart.component.ts
+++ b/frontend/src/app/components/fhir-card/common/observation-bar-chart/observation-bar-chart.component.ts
@@ -15,7 +15,7 @@ const defaultChartEntryHeight = 30;
   styleUrls: ['./observation-bar-chart.component.scss']
 })
 export class ObservationBarChartComponent implements OnInit {
-  @Input() observations: [ObservationModel]
+  @Input() observations: ObservationModel[]
 
   chartHeight = defaultChartEntryHeight;
 
@@ -122,14 +122,21 @@ export class ObservationBarChartComponent implements OnInit {
       return;
     }
 
-    let currentValues: number[] = []
+    let currentValues = []
     let referenceRanges = []
 
     for(let observation of this.observations) {
       let refRange = observation.reference_range;
 
       referenceRanges.push([refRange.low || 0, refRange.high || 0]);
-      currentValues.push(observation.value_quantity_value);
+
+      let value = observation.value_object;
+
+      if (value.range) {
+        currentValues.push([value.range.low, value.range.high]);
+      } else {
+        currentValues.push([value.value, value.value])
+      }
 
       if (observation.effective_date) {
         this.barChartLabels.push(formatDate(observation.effective_date, "mediumDate", "en-US", undefined));
@@ -141,7 +148,7 @@ export class ObservationBarChartComponent implements OnInit {
       this.barChartData[1]['dataLabels'].push(observation.value_quantity_unit);
     }
 
-    let xAxisMax = Math.max(...currentValues) * 1.3;
+    let xAxisMax = Math.max(...currentValues.map(set => set[1])) * 1.3;
     this.barChartOptions.scales['x']['max'] = xAxisMax
 
     let updatedRefRanges = referenceRanges.map(range => {
@@ -154,7 +161,7 @@ export class ObservationBarChartComponent implements OnInit {
 
     // @ts-ignore
     this.barChartData[0].data = updatedRefRanges
-    this.barChartData[1].data = currentValues.map(v => [v, v])
+    this.barChartData[1].data = currentValues
 
     this.chartHeight = defaultChartHeight + (defaultChartEntryHeight * currentValues.length)
   }

--- a/frontend/src/app/components/fhir-card/common/observation-bar-chart/observation-bar-chart.stories.ts
+++ b/frontend/src/app/components/fhir-card/common/observation-bar-chart/observation-bar-chart.stories.ts
@@ -33,6 +33,12 @@ export const NoRange: Story = {
   }
 };
 
+export const ValueStringWithRange: Story = {
+  args: {
+    observations: [new ObservationModel(observationR4Factory.valueString('<10 IntlUnit/mL').referenceRangeOnlyHigh(50).build(), fhirVersions.R4)]
+  }
+};
+
 export const Range: Story = {
   args: {
     observations: [new ObservationModel(observationR4Factory.referenceRange().build(), fhirVersions.R4)]

--- a/frontend/src/lib/fixtures/factories/r4/resources/observation-r4-factory.ts
+++ b/frontend/src/lib/fixtures/factories/r4/resources/observation-r4-factory.ts
@@ -9,6 +9,18 @@ class ObservationR4Factory extends Factory<{}> {
     })
   }
 
+  valueQuantity(params: {}) {
+    return this.params({
+      valueQuantity: {
+        value: params['value'] || 6.3,
+        unit: params['unit'] || 'mmol/l',
+        system: 'http://unitsofmeasure.org',
+        code: params['code'] || 'mmol/L',
+        comparator: params['comparator']
+      }
+    })
+  }
+
   referenceRange(high?: number, low?: number) {
     return this.params({
       referenceRange: [

--- a/frontend/src/lib/models/resources/observation-model.spec.ts
+++ b/frontend/src/lib/models/resources/observation-model.spec.ts
@@ -11,6 +11,35 @@ describe('ObservationModel', () => {
     it('reads from valueQuantity.value if set', () => {
       let observation = new ObservationModel(observationR4Factory.build(), fhirVersions.R4);
 
+      expect(observation.value_object.value).toEqual(6.3);
+    });
+
+    it('parses valueString correctly when value is a number if valueQuantity.value not set', () => {
+      let observation = new ObservationModel(observationR4Factory.valueString().build(), fhirVersions.R4);
+
+      expect(observation.value_object.value).toEqual(5.5);
+    });
+
+    it('parses value correctly when valueQuantity.comparator is set', () => {
+      let observation = new ObservationModel(observationR4Factory.valueQuantity({ comparator: '<', value: 8 }).build(), fhirVersions.R4);
+      let observation2 = new ObservationModel(observationR4Factory.valueQuantity({ comparator: '>', value: 8 }).build(), fhirVersions.R4);
+
+      expect(observation.value_object).toEqual({ range: { low: null, high: 8 } });
+      expect(observation2.value_object).toEqual({ range: { low: 8, high: null } });
+    });
+
+    it('parses value correctly when valueString has a range', () => {
+      let observation = new ObservationModel(observationR4Factory.valueString('<10 IntlUnit/mL').build(), fhirVersions.R4);
+      let observation2 = new ObservationModel(observationR4Factory.valueString('>10 IntlUnit/mL').build(), fhirVersions.R4);
+
+      expect(observation.value_object).toEqual({ range: { low: null, high: 10 } });
+      expect(observation2.value_object).toEqual({ range: { low: 10, high: null } });
+    });
+
+    // following two tests being kept temporarily. will be removed in next PR when I remove value_quantity_value
+    it('reads from valueQuantity.value if set', () => {
+      let observation = new ObservationModel(observationR4Factory.build(), fhirVersions.R4);
+
       expect(observation.value_quantity_value).toEqual(6.3);
     });
 
@@ -20,6 +49,7 @@ describe('ObservationModel', () => {
       expect(observation.value_quantity_value).toEqual(5.5);
     });
   });
+
 
   describe('parsing unit', () => {
     it('reads from valueQuantity.unit if set', () => {


### PR DESCRIPTION
# Description

Right now lab values that have a `<` are parsed as 0. This PR adds some quick parsing so that these are displayed like reference ranges are. 

Fixes #441

## Changes

- Update observation model to check for ranged values in valueString and the comparator attribute in valueQuantity and return a `ValueObject`
- Update bar chart to use new `ValueObject` for values instead of `value_quantity_value`
  - Normally I would fully remove this value, but I am leaving it for now because it is used in places that I'll be updating soon as part of my changes to address #360. 
- Add `valueQuantity` trait to observation factory to allow custom values
- Added an observation bar chart story to test display of a ranged value
  - Note: The tooltip is a little wonky with the text display and the color of the result is a little off if there is also a range, but I figure for now this is fine as at least the result is readable without having to dig into the debug json <img width="867" alt="Screen Shot 2024-03-17 at 11 25 30 PM" src="https://github.com/fastenhealth/fasten-onprem/assets/55406257/f1d1689c-2f2a-4a44-8033-49b7ca55e978">

