### PR TITLE
Fix broken image path

### DIFF
--- a/frontend/src/app/directives/image-fallback.directive.ts
+++ b/frontend/src/app/directives/image-fallback.directive.ts
@@ -1,6 +1,6 @@
 import {Directive, ElementRef, HostListener, Input} from '@angular/core';
 
-const DEFAULT_IMAGE_FALLBACK_PATH: string = '/assets/images/no-image.svg';
+const DEFAULT_IMAGE_FALLBACK_PATH: string = 'assets/images/no-image.svg';
 
 @Directive({
   selector: 'img[imageFallback]'


### PR DESCRIPTION
# Description

When I fixed the image fallback directive to not infinitely loop in #444, I accidentally updated the fallback path to `/assets/images/no-image.svg` instead of `assets/images/no-image.svg`. This is making the path be treated as an absolute and is ignoring the configured base href of `/web/`. 

Didn't notice because storybook doesn't run under a base href. I wasn't able to figure out a way to make storybook run under a base ref like the normal site does, but if you run the site locally in sandbox mode you can see the difference between main and this branch as the Dynamic Health IT and AdvancedMD sources do not have images.

# Changes
- remove leading `/` in asset path of image fallback

## Screenshots

before:
<img width="913" alt="Screen Shot 2024-04-23 at 1 14 39 PM" src="https://github.com/fastenhealth/fasten-onprem/assets/55406257/cee05fd2-e466-44cb-b691-6a7ccecee4d3">

after:
<img width="922" alt="Screen Shot 2024-04-23 at 1 13 35 PM" src="https://github.com/fastenhealth/fasten-onprem/assets/55406257/d460f1a2-6f44-4a3d-8a1f-469d2d988d32">
