### PR TITLE
don't show date if the job isn't done

### DIFF
--- a/frontend/src/app/pages/background-jobs/background-jobs.component.html
+++ b/frontend/src/app/pages/background-jobs/background-jobs.component.html
@@ -41,7 +41,9 @@
                                      'badge-danger': backgroundJob.job_status == 'STATUS_FAILED'
                         }">{{backgroundJob.job_status}}</label></td>
                         <td container="body" [ngbTooltip]="backgroundJob.locked_time | amDateFormat:'YYYY-MM-DD HH:mm'">{{backgroundJob.locked_time | amTimeAgo}}</td>
-                        <td container="body" [ngbTooltip]="backgroundJob.done_time | amDateFormat:'YYYY-MM-DD HH:mm'">{{backgroundJob.done_time | amTimeAgo}}</td>
+                        <td container="body">
+                          <span *ngIf="backgroundJob.done_time" [ngbTooltip]="backgroundJob.done_time | amDateFormat:'YYYY-MM-DD HH:mm'">{{backgroundJob.done_time | amTimeAgo}}</span>
+                        </td>
                         <td>
                           <button (click)="openModal(content, backgroundJob)" class="btn btn-outline-indigo btn-with-icon btn-rounded"><i class="fa fa-info-circle"></i> Details</button>
                         </td>


### PR DESCRIPTION
Without this, the background jobs page shows "Invalid date" if there's a job running.