### PR TITLE
use upload-artifact v4 to fix CI

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -24,9 +24,9 @@ jobs:
         run: |
           make test-frontend-coverage
       - name: Upload coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: frontend-coverage
           path: ${{ github.workspace }}/frontend/coverage/fastenhealth/lcov.info
           retention-days: 1
   test-backend:
@@ -47,9 +47,9 @@ jobs:
           make test-backend-coverage
           CGO_ENABLED=0 go build -buildvcs=false ./backend/cmd/fasten/
       - name: Upload coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: backend-coverage
           path: ${{ github.workspace }}/backend-coverage.txt
           retention-days: 1
   compile-storybook:


### PR DESCRIPTION
CI is currently broken due to a deprecated github action. This upgrades the action to the latest version.