### PR TITLE
fix sources page ui jump

### DIFF
--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -246,17 +246,7 @@ app-nlm-typeahead {
 
 app-medical-sources-filter > .az-content-left-components {
   overflow-x: hidden;
-  -webkit-transition: width 0.2s ease-in-out;
-  -moz-transition: width 0.2s ease-in-out;
-  -o-transition: width 0.2s ease-in-out;
-  transition: width 0.2s ease-in-out;
-}
-app-medical-sources-filter > .az-content-left-components:hover{
-  width: 100%;
-  -webkit-transition: width 0.2s ease-in-out;
-  -moz-transition: width 0.2s ease-in-out;
-  -o-transition: width 0.2s ease-in-out;
-  transition: width 0.2s ease-in-out;
+  width: 280px;
 }
 
 //Fhir Datadable


### PR DESCRIPTION
There's a ui bug on the sources page where the left sidebar panel and the main content panel sizes jump back and forth as the mouse hovers over each. This fixes it.