### PR TITLE
Dark mode

### DIFF
--- a/frontend/src/app/components/header/header.component.html
+++ b/frontend/src/app/components/header/header.component.html
@@ -56,6 +56,9 @@
           <div class="dropdown-footer"><a routerLink="/background-jobs">View History</a></div>
         </div><!-- dropdown-menu -->
       </div><!-- az-header-notification -->
+      <div class="az-header-theme-toggle" >
+        <a class="" (click)="toggleTheme()" ><i class="far fa-sm fa-{{ isDarkMode ? 'sun' : 'moon' }}"></i></a>
+      </div>
       <div class="dropdown az-profile-menu" ngbDropdown>
         <a class="az-img-user" id="profileDropdown" ngbDropdownToggle><img src="assets/logo/logo-text.png" alt="user"></a>
         <div class="dropdown-menu" ngbDropdownMenu aria-labelledby="profileDropdown">

--- a/frontend/src/app/components/header/header.component.ts
+++ b/frontend/src/app/components/header/header.component.ts
@@ -10,6 +10,7 @@ import {environment} from '../../../environments/environment';
 import {versionInfo} from '../../../environments/versions';
 import {Subscription} from 'rxjs';
 import {ToastNotification, ToastType} from '../../models/fasten/toast';
+import {ThemeService} from '../../theme.service';
 
 @Component({
   selector: 'app-header',
@@ -30,12 +31,16 @@ export class HeaderComponent implements OnInit, OnDestroy {
   is_environment_desktop: boolean = environment.environment_desktop
 
   isAdmin: boolean = false;
+  isDarkMode: boolean;
 
   constructor(
     private authService: AuthService,
     private router: Router,
     private fastenApi: FastenApiService,
-    private modalService: NgbModal) { }
+    private modalService: NgbModal,
+    private themeService: ThemeService) { 
+      this.isDarkMode = this.themeService.isDarkMode();
+    }
 
   ngOnInit() {
     try {
@@ -74,6 +79,11 @@ export class HeaderComponent implements OnInit, OnDestroy {
   toggleHeaderMenu(event) {
     event.preventDefault();
     document.querySelector('body').classList.toggle('az-header-menu-show');
+  }
+
+  toggleTheme() {
+    this.isDarkMode = !this.isDarkMode;
+    this.themeService.setDarkMode(this.isDarkMode);
   }
 
   signOut(e) {

--- a/frontend/src/app/theme.service.spec.ts
+++ b/frontend/src/app/theme.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ThemeService } from './theme.service';
+
+describe('ThemeService', () => {
+  let service: ThemeService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ThemeService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/src/app/theme.service.ts
+++ b/frontend/src/app/theme.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ThemeService {
+  private darkMode = false;
+
+  constructor() { }
+
+  isDarkMode() {
+    return this.darkMode;
+  }
+
+  setDarkMode(isDarkMode: boolean) {
+    this.darkMode = isDarkMode;
+    if (isDarkMode) {
+      document.body.classList.add('dark-theme');
+    } else {
+      document.body.classList.remove('dark-theme');
+    }
+  }
+}

--- a/frontend/src/assets/scss/layout/_global.scss
+++ b/frontend/src/assets/scss/layout/_global.scss
@@ -57,3 +57,8 @@ body {
     }
   }
 }
+
+.dark-theme {
+  background-color: #222;
+  color: #fff;
+}

--- a/frontend/src/assets/scss/layout/_header.scss
+++ b/frontend/src/assets/scss/layout/_header.scss
@@ -838,3 +838,14 @@
   right: 0;
   z-index: 1000;
 }
+
+.az-header-theme-toggle {
+  margin-left: 15px;
+
+  i {
+    font-size: 18px;
+    line-height: 0;
+    color: $gray-900;
+  }
+  
+}


### PR DESCRIPTION
The white background was a bit much for me working on this in my evening hours. This is a UI(frontend/client side) toggle for dark mode that isn't saved in the current version. 

I didn't know if this should be moved to the footer or left in the header? 

Future Work needed:
* Could be saved via cookie or user profile in future PR 
* Need the dark theme. This just sets background-color black for now which needs a proper color scheme

