### PR TITLE
Update docker-compose-prod.yml

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   fasten-prod:
     image: ghcr.io/fastenhealth/fasten-onprem:main


### PR DESCRIPTION
Compose no longer uses Version numbers. Removing prevents log warnings