### PR TITLE
feat: add edit and delete for manual source resources

### DIFF
--- a/backend/pkg/database/gorm_common.go
+++ b/backend/pkg/database/gorm_common.go
@@ -580,6 +580,142 @@ func (gr *GormRepository) GetResourceBySourceId(ctx context.Context, sourceId st
 	}
 }
 
+func (gr *GormRepository) DeleteResourceBySourceId(ctx context.Context, sourceId string, sourceResourceId string) (int64, error) {
+	currentUser, currentUserErr := gr.GetCurrentUser(ctx)
+	if currentUserErr != nil {
+		return 0, currentUserErr
+	}
+
+	sourceUUID, err := uuid.Parse(sourceId)
+	if err != nil {
+		return 0, err
+	}
+
+	// check that the source is a manual or fasten source
+	sourceCred, err := gr.GetSource(ctx, sourceId)
+	if err != nil {
+		return 0, err
+	}
+	if sourceCred.PlatformType != sourcePkg.PlatformTypeFasten && sourceCred.PlatformType != sourcePkg.PlatformTypeManual {
+		return 0, fmt.Errorf("deleting individual resources is only allowed for manual/fasten sources")
+	}
+
+	// find the resource across all tables
+	queryParam := models.OriginBase{
+		UserID:           currentUser.ID,
+		SourceID:         sourceUUID,
+		SourceResourceID: sourceResourceId,
+	}
+	wrappedResourceModels, err := gr.getResourcesFromAllTables(gr.GormClient.WithContext(ctx), queryParam)
+	if err != nil {
+		return 0, err
+	}
+	if len(wrappedResourceModels) == 0 {
+		return 0, fmt.Errorf("resource not found")
+	}
+
+	resource := wrappedResourceModels[0]
+	tableName, err := databaseModel.GetTableNameByResourceType(resource.SourceResourceType)
+	if err != nil {
+		return 0, err
+	}
+
+	// delete related resource associations (both directions)
+	gr.GormClient.WithContext(ctx).
+		Where("resource_base_user_id = ? AND resource_base_source_id = ? AND resource_base_source_resource_id = ?",
+			currentUser.ID, sourceUUID, sourceResourceId).
+		Table("related_resources").
+		Delete(&models.RelatedResource{})
+	gr.GormClient.WithContext(ctx).
+		Where("related_resource_user_id = ? AND related_resource_source_id = ? AND related_resource_source_resource_id = ?",
+			currentUser.ID, sourceUUID, sourceResourceId).
+		Table("related_resources").
+		Delete(&models.RelatedResource{})
+
+	// soft-delete the resource
+	results := gr.GormClient.WithContext(ctx).
+		Where(models.OriginBase{
+			UserID:           currentUser.ID,
+			SourceID:         sourceUUID,
+			SourceResourceID: sourceResourceId,
+		}).
+		Table(tableName).
+		Delete(&models.ResourceBase{})
+
+	return results.RowsAffected, results.Error
+}
+
+func (gr *GormRepository) UpdateResourceBySourceId(ctx context.Context, sourceId string, sourceResourceId string, resourceRaw datatypes.JSON) error {
+	currentUser, currentUserErr := gr.GetCurrentUser(ctx)
+	if currentUserErr != nil {
+		return currentUserErr
+	}
+
+	sourceUUID, err := uuid.Parse(sourceId)
+	if err != nil {
+		return err
+	}
+
+	// check that the source is a manual or fasten source
+	sourceCred, err := gr.GetSource(ctx, sourceId)
+	if err != nil {
+		return err
+	}
+	if sourceCred.PlatformType != sourcePkg.PlatformTypeFasten && sourceCred.PlatformType != sourcePkg.PlatformTypeManual {
+		return fmt.Errorf("updating individual resources is only allowed for manual/fasten sources")
+	}
+
+	// find the existing resource
+	queryParam := models.OriginBase{
+		UserID:           currentUser.ID,
+		SourceID:         sourceUUID,
+		SourceResourceID: sourceResourceId,
+	}
+	wrappedResourceModels, err := gr.getResourcesFromAllTables(gr.GormClient.WithContext(ctx), queryParam)
+	if err != nil {
+		return err
+	}
+	if len(wrappedResourceModels) == 0 {
+		return fmt.Errorf("resource not found")
+	}
+
+	resource := wrappedResourceModels[0]
+
+	// create a typed FHIR model and re-index search parameters
+	wrappedFhirResourceModel, err := databaseModel.NewFhirResourceModelByType(resource.SourceResourceType)
+	if err != nil {
+		return err
+	}
+
+	wrappedFhirResourceModel.SetOriginBase(resource.OriginBase)
+	wrappedFhirResourceModel.SetSortTitle(resource.SortTitle)
+	wrappedFhirResourceModel.SetSortDate(resource.SortDate)
+	wrappedFhirResourceModel.SetSourceUri(resource.SourceUri)
+	wrappedFhirResourceModel.SetResourceRaw(resourceRaw)
+
+	err = wrappedFhirResourceModel.PopulateAndExtractSearchParameters(json.RawMessage(resourceRaw))
+	if err != nil {
+		gr.Logger.Warnf("ignoring: an error occurred while extracting SearchParameters using FHIRPath (%s/%s): %v", resource.SourceResourceType, resource.SourceResourceID, err)
+	}
+
+	tableName, err := databaseModel.GetTableNameByResourceType(resource.SourceResourceType)
+	if err != nil {
+		return err
+	}
+
+	// update the resource in the correct table
+	results := gr.GormClient.WithContext(ctx).
+		Table(tableName).
+		Where(models.OriginBase{
+			UserID:           currentUser.ID,
+			SourceID:         sourceUUID,
+			SourceResourceID: sourceResourceId,
+		}).
+		Updates(wrappedFhirResourceModel)
+
+	return results.Error
+}
+
 // Get the patient for each source (for the current user)
 func (gr *GormRepository) GetPatientForSources(ctx context.Context) ([]models.ResourceBase, error) {
 	currentUser, currentUserErr := gr.GetCurrentUser(ctx)

--- a/backend/pkg/database/gorm_repository_test.go
+++ b/backend/pkg/database/gorm_repository_test.go
@@ -2091,3 +2091,274 @@ func (suite *RepositoryTestSuite) TestRemoveBulkResourceAssociations_Success() {
 	require.Equal(suite.T(), "obs101", proc101Associations[0].ResourceBaseSourceResourceID)
 	require.Equal(suite.T(), sc1.ID, proc101Associations[0].ResourceBaseSourceID) // Check the base source ID
 }
+
+func (suite *RepositoryTestSuite) TestDeleteResourceBySourceId() {
+	//setup
+	fakeConfig := mock_config.NewMockInterface(suite.MockCtrl)
+	fakeConfig.EXPECT().GetString("database.location").Return(suite.TestDatabase.Name()).AnyTimes()
+	fakeConfig.EXPECT().GetString("database.type").Return("sqlite").AnyTimes()
+	fakeConfig.EXPECT().IsSet("database.encryption.key").Return(false).AnyTimes()
+	fakeConfig.EXPECT().GetString("log.level").Return("INFO").AnyTimes()
+	dbRepo, err := NewRepository(fakeConfig, logrus.WithField("test", suite.T().Name()), event_bus.NewNoopEventBusServer())
+	require.NoError(suite.T(), err)
+
+	userModel := &models.User{
+		Username: "test_username",
+		Password: "testpassword",
+		Email:    "test@test.com",
+	}
+	err = dbRepo.CreateUser(context.Background(), userModel)
+	require.NoError(suite.T(), err)
+	authContext := context.WithValue(context.Background(), pkg.ContextKeyTypeAuthUsername, "test_username")
+
+	// create a manual source
+	manualSourceCredential := models.SourceCredential{
+		ModelBase:    models.ModelBase{ID: uuid.New()},
+		UserID:       userModel.ID,
+		Patient:      "test-patient",
+		PlatformType: sourcePkg.PlatformTypeManual,
+	}
+	err = dbRepo.CreateSource(authContext, &manualSourceCredential)
+	require.NoError(suite.T(), err)
+
+	testPatientData, err := os.ReadFile("./testdata/Abraham100_Heller342_Patient.json")
+	require.NoError(suite.T(), err)
+
+	wasCreated, err := dbRepo.UpsertRawResource(
+		authContext,
+		&manualSourceCredential,
+		sourceModels.RawResourceFhir{
+			SourceResourceType: "Patient",
+			SourceResourceID:   "b426b062-8273-4b93-a907-de3176c0567d",
+			ResourceRaw:        testPatientData,
+		},
+	)
+	require.NoError(suite.T(), err)
+	require.True(suite.T(), wasCreated)
+
+	// verify resource exists before delete
+	foundResource, err := dbRepo.GetResourceBySourceId(authContext, manualSourceCredential.ID.String(), "b426b062-8273-4b93-a907-de3176c0567d")
+	require.NoError(suite.T(), err)
+	require.NotNil(suite.T(), foundResource)
+
+	//test
+	rowsAffected, err := dbRepo.DeleteResourceBySourceId(authContext, manualSourceCredential.ID.String(), "b426b062-8273-4b93-a907-de3176c0567d")
+
+	//assert
+	require.NoError(suite.T(), err)
+	require.Equal(suite.T(), int64(1), rowsAffected)
+
+	// verify resource no longer exists
+	_, err = dbRepo.GetResourceBySourceId(authContext, manualSourceCredential.ID.String(), "b426b062-8273-4b93-a907-de3176c0567d")
+	require.Error(suite.T(), err)
+}
+
+func (suite *RepositoryTestSuite) TestDeleteResourceBySourceId_WithNonManualSource_ShouldFail() {
+	//setup
+	fakeConfig := mock_config.NewMockInterface(suite.MockCtrl)
+	fakeConfig.EXPECT().GetString("database.location").Return(suite.TestDatabase.Name()).AnyTimes()
+	fakeConfig.EXPECT().GetString("database.type").Return("sqlite").AnyTimes()
+	fakeConfig.EXPECT().IsSet("database.encryption.key").Return(false).AnyTimes()
+	fakeConfig.EXPECT().GetString("log.level").Return("INFO").AnyTimes()
+	dbRepo, err := NewRepository(fakeConfig, logrus.WithField("test", suite.T().Name()), event_bus.NewNoopEventBusServer())
+	require.NoError(suite.T(), err)
+
+	userModel := &models.User{
+		Username: "test_username",
+		Password: "testpassword",
+		Email:    "test@test.com",
+	}
+	err = dbRepo.CreateUser(context.Background(), userModel)
+	require.NoError(suite.T(), err)
+	authContext := context.WithValue(context.Background(), pkg.ContextKeyTypeAuthUsername, "test_username")
+
+	// create a non-manual source (e.g. bluebutton)
+	nonManualSourceCredential := models.SourceCredential{
+		ModelBase:    models.ModelBase{ID: uuid.New()},
+		UserID:       userModel.ID,
+		Patient:      "test-patient",
+		PlatformType: sourcePkg.PlatformType("bluebutton"),
+	}
+	err = dbRepo.CreateSource(authContext, &nonManualSourceCredential)
+	require.NoError(suite.T(), err)
+
+	testPatientData, err := os.ReadFile("./testdata/Abraham100_Heller342_Patient.json")
+	require.NoError(suite.T(), err)
+
+	wasCreated, err := dbRepo.UpsertRawResource(
+		authContext,
+		&nonManualSourceCredential,
+		sourceModels.RawResourceFhir{
+			SourceResourceType: "Patient",
+			SourceResourceID:   "b426b062-8273-4b93-a907-de3176c0567d",
+			ResourceRaw:        testPatientData,
+		},
+	)
+	require.NoError(suite.T(), err)
+	require.True(suite.T(), wasCreated)
+
+	//test - should fail because source is not manual/fasten
+	_, err = dbRepo.DeleteResourceBySourceId(authContext, nonManualSourceCredential.ID.String(), "b426b062-8273-4b93-a907-de3176c0567d")
+
+	//assert
+	require.Error(suite.T(), err)
+	require.Contains(suite.T(), err.Error(), "only allowed for manual")
+}
+
+func (suite *RepositoryTestSuite) TestDeleteResourceBySourceId_WithInvalidResourceId_ShouldFail() {
+	//setup
+	fakeConfig := mock_config.NewMockInterface(suite.MockCtrl)
+	fakeConfig.EXPECT().GetString("database.location").Return(suite.TestDatabase.Name()).AnyTimes()
+	fakeConfig.EXPECT().GetString("database.type").Return("sqlite").AnyTimes()
+	fakeConfig.EXPECT().IsSet("database.encryption.key").Return(false).AnyTimes()
+	fakeConfig.EXPECT().GetString("log.level").Return("INFO").AnyTimes()
+	dbRepo, err := NewRepository(fakeConfig, logrus.WithField("test", suite.T().Name()), event_bus.NewNoopEventBusServer())
+	require.NoError(suite.T(), err)
+
+	userModel := &models.User{
+		Username: "test_username",
+		Password: "testpassword",
+		Email:    "test@test.com",
+	}
+	err = dbRepo.CreateUser(context.Background(), userModel)
+	require.NoError(suite.T(), err)
+	authContext := context.WithValue(context.Background(), pkg.ContextKeyTypeAuthUsername, "test_username")
+
+	manualSourceCredential := models.SourceCredential{
+		ModelBase:    models.ModelBase{ID: uuid.New()},
+		UserID:       userModel.ID,
+		Patient:      "test-patient",
+		PlatformType: sourcePkg.PlatformTypeManual,
+	}
+	err = dbRepo.CreateSource(authContext, &manualSourceCredential)
+	require.NoError(suite.T(), err)
+
+	//test - resource doesn't exist
+	_, err = dbRepo.DeleteResourceBySourceId(authContext, manualSourceCredential.ID.String(), "does-not-exist")
+
+	//assert
+	require.Error(suite.T(), err)
+	require.Contains(suite.T(), err.Error(), "resource not found")
+}
+
+func (suite *RepositoryTestSuite) TestUpdateResourceBySourceId() {
+	//setup
+	fakeConfig := mock_config.NewMockInterface(suite.MockCtrl)
+	fakeConfig.EXPECT().GetString("database.location").Return(suite.TestDatabase.Name()).AnyTimes()
+	fakeConfig.EXPECT().GetString("database.type").Return("sqlite").AnyTimes()
+	fakeConfig.EXPECT().IsSet("database.encryption.key").Return(false).AnyTimes()
+	fakeConfig.EXPECT().GetString("log.level").Return("INFO").AnyTimes()
+	dbRepo, err := NewRepository(fakeConfig, logrus.WithField("test", suite.T().Name()), event_bus.NewNoopEventBusServer())
+	require.NoError(suite.T(), err)
+
+	userModel := &models.User{
+		Username: "test_username",
+		Password: "testpassword",
+		Email:    "test@test.com",
+	}
+	err = dbRepo.CreateUser(context.Background(), userModel)
+	require.NoError(suite.T(), err)
+	authContext := context.WithValue(context.Background(), pkg.ContextKeyTypeAuthUsername, "test_username")
+
+	// create a fasten source
+	fastenSourceCredential := models.SourceCredential{
+		ModelBase:    models.ModelBase{ID: uuid.New()},
+		UserID:       userModel.ID,
+		Patient:      "test-patient",
+		PlatformType: sourcePkg.PlatformTypeFasten,
+	}
+	err = dbRepo.CreateSource(authContext, &fastenSourceCredential)
+	require.NoError(suite.T(), err)
+
+	testPatientData, err := os.ReadFile("./testdata/Abraham100_Heller342_Patient.json")
+	require.NoError(suite.T(), err)
+
+	wasCreated, err := dbRepo.UpsertRawResource(
+		authContext,
+		&fastenSourceCredential,
+		sourceModels.RawResourceFhir{
+			SourceResourceType: "Patient",
+			SourceResourceID:   "b426b062-8273-4b93-a907-de3176c0567d",
+			ResourceRaw:        testPatientData,
+		},
+	)
+	require.NoError(suite.T(), err)
+	require.True(suite.T(), wasCreated)
+
+	//test - update the resource with new raw data
+	updatedRaw, err := json.Marshal(map[string]interface{}{
+		"resourceType": "Patient",
+		"id":           "b426b062-8273-4b93-a907-de3176c0567d",
+		"name":         []map[string]interface{}{{"family": "UpdatedName", "given": []string{"Test"}}},
+	})
+	require.NoError(suite.T(), err)
+
+	err = dbRepo.UpdateResourceBySourceId(authContext, fastenSourceCredential.ID.String(), "b426b062-8273-4b93-a907-de3176c0567d", updatedRaw)
+
+	//assert
+	require.NoError(suite.T(), err)
+
+	// verify the resource was updated
+	foundResource, err := dbRepo.GetResourceBySourceId(authContext, fastenSourceCredential.ID.String(), "b426b062-8273-4b93-a907-de3176c0567d")
+	require.NoError(suite.T(), err)
+	require.NotNil(suite.T(), foundResource)
+
+	var actualData map[string]interface{}
+	err = json.Unmarshal(foundResource.ResourceRaw, &actualData)
+	require.NoError(suite.T(), err)
+	require.Equal(suite.T(), "Patient", actualData["resourceType"])
+}
+
+func (suite *RepositoryTestSuite) TestUpdateResourceBySourceId_WithNonManualSource_ShouldFail() {
+	//setup
+	fakeConfig := mock_config.NewMockInterface(suite.MockCtrl)
+	fakeConfig.EXPECT().GetString("database.location").Return(suite.TestDatabase.Name()).AnyTimes()
+	fakeConfig.EXPECT().GetString("database.type").Return("sqlite").AnyTimes()
+	fakeConfig.EXPECT().IsSet("database.encryption.key").Return(false).AnyTimes()
+	fakeConfig.EXPECT().GetString("log.level").Return("INFO").AnyTimes()
+	dbRepo, err := NewRepository(fakeConfig, logrus.WithField("test", suite.T().Name()), event_bus.NewNoopEventBusServer())
+	require.NoError(suite.T(), err)
+
+	userModel := &models.User{
+		Username: "test_username",
+		Password: "testpassword",
+		Email:    "test@test.com",
+	}
+	err = dbRepo.CreateUser(context.Background(), userModel)
+	require.NoError(suite.T(), err)
+	authContext := context.WithValue(context.Background(), pkg.ContextKeyTypeAuthUsername, "test_username")
+
+	nonManualSourceCredential := models.SourceCredential{
+		ModelBase:    models.ModelBase{ID: uuid.New()},
+		UserID:       userModel.ID,
+		Patient:      "test-patient",
+		PlatformType: sourcePkg.PlatformType("bluebutton"),
+	}
+	err = dbRepo.CreateSource(authContext, &nonManualSourceCredential)
+	require.NoError(suite.T(), err)
+
+	testPatientData, err := os.ReadFile("./testdata/Abraham100_Heller342_Patient.json")
+	require.NoError(suite.T(), err)
+
+	wasCreated, err := dbRepo.UpsertRawResource(
+		authContext,
+		&nonManualSourceCredential,
+		sourceModels.RawResourceFhir{
+			SourceResourceType: "Patient",
+			SourceResourceID:   "b426b062-8273-4b93-a907-de3176c0567d",
+			ResourceRaw:        testPatientData,
+		},
+	)
+	require.NoError(suite.T(), err)
+	require.True(suite.T(), wasCreated)
+
+	//test - should fail because source is not manual/fasten
+	updatedRaw, err := json.Marshal(map[string]interface{}{"resourceType": "Patient", "id": "b426b062-8273-4b93-a907-de3176c0567d"})
+	require.NoError(suite.T(), err)
+
+	err = dbRepo.UpdateResourceBySourceId(authContext, nonManualSourceCredential.ID.String(), "b426b062-8273-4b93-a907-de3176c0567d", updatedRaw)
+
+	//assert
+	require.Error(suite.T(), err)
+	require.Contains(suite.T(), err.Error(), "only allowed for manual")
+}

--- a/backend/pkg/database/interface.go
+++ b/backend/pkg/database/interface.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fastenhealth/fasten-onprem/backend/pkg/utils/ips"
 	sourcePkg "github.com/fastenhealth/fasten-sources/clients/models"
 	"github.com/google/uuid"
+	"gorm.io/datatypes"
 )
 
 //go:generate mockgen -source=interface.go -destination=mock/mock_database.go
@@ -28,6 +29,8 @@ type DatabaseRepository interface {
 
 	GetResourceByResourceTypeAndId(context.Context, string, string) (*models.ResourceBase, error)
 	GetResourceBySourceId(context.Context, string, string) (*models.ResourceBase, error)
+	DeleteResourceBySourceId(ctx context.Context, sourceId string, sourceResourceId string) (int64, error)
+	UpdateResourceBySourceId(ctx context.Context, sourceId string, sourceResourceId string, resourceRaw datatypes.JSON) error
 	QueryResources(ctx context.Context, query models.QueryResource) (interface{}, error)
 	ListResources(context.Context, models.ListResourceQueryOptions) ([]models.ResourceBase, error)
 	GetPatientForSources(ctx context.Context) ([]models.ResourceBase, error)

--- a/backend/pkg/database/mock/mock_database.go
+++ b/backend/pkg/database/mock/mock_database.go
@@ -14,6 +14,7 @@ import (
 	models0 "github.com/fastenhealth/fasten-sources/clients/models"
 	gomock "github.com/golang/mock/gomock"
 	uuid "github.com/google/uuid"
+	datatypes "gorm.io/datatypes"
 )
 
 // MockDatabaseRepository is a mock of DatabaseRepository interface.
@@ -161,6 +162,21 @@ func (m *MockDatabaseRepository) DeleteCurrentUser(ctx context.Context) error {
 func (mr *MockDatabaseRepositoryMockRecorder) DeleteCurrentUser(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCurrentUser", reflect.TypeOf((*MockDatabaseRepository)(nil).DeleteCurrentUser), ctx)
+}
+
+// DeleteResourceBySourceId mocks base method.
+func (m *MockDatabaseRepository) DeleteResourceBySourceId(ctx context.Context, sourceId, sourceResourceId string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteResourceBySourceId", ctx, sourceId, sourceResourceId)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteResourceBySourceId indicates an expected call of DeleteResourceBySourceId.
+func (mr *MockDatabaseRepositoryMockRecorder) DeleteResourceBySourceId(ctx, sourceId, sourceResourceId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResourceBySourceId", reflect.TypeOf((*MockDatabaseRepository)(nil).DeleteResourceBySourceId), ctx, sourceId, sourceResourceId)
 }
 
 // DeleteSource mocks base method.
@@ -620,6 +636,20 @@ func (m *MockDatabaseRepository) UpdateBackgroundJob(ctx context.Context, backgr
 func (mr *MockDatabaseRepositoryMockRecorder) UpdateBackgroundJob(ctx, backgroundJob interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackgroundJob", reflect.TypeOf((*MockDatabaseRepository)(nil).UpdateBackgroundJob), ctx, backgroundJob)
+}
+
+// UpdateResourceBySourceId mocks base method.
+func (m *MockDatabaseRepository) UpdateResourceBySourceId(ctx context.Context, sourceId, sourceResourceId string, resourceRaw datatypes.JSON) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateResourceBySourceId", ctx, sourceId, sourceResourceId, resourceRaw)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateResourceBySourceId indicates an expected call of UpdateResourceBySourceId.
+func (mr *MockDatabaseRepositoryMockRecorder) UpdateResourceBySourceId(ctx, sourceId, sourceResourceId, resourceRaw interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateResourceBySourceId", reflect.TypeOf((*MockDatabaseRepository)(nil).UpdateResourceBySourceId), ctx, sourceId, sourceResourceId, resourceRaw)
 }
 
 // UpdateSource mocks base method.

--- a/backend/pkg/web/handler/resource_fhir.go
+++ b/backend/pkg/web/handler/resource_fhir.go
@@ -11,8 +11,8 @@ import (
 	"github.com/fastenhealth/fasten-onprem/backend/pkg"
 	"github.com/fastenhealth/fasten-onprem/backend/pkg/database"
 	"github.com/fastenhealth/fasten-onprem/backend/pkg/models"
-	sourceModels "github.com/fastenhealth/fasten-sources/clients/models"
 	"github.com/fastenhealth/fasten-onprem/backend/pkg/utils"
+	sourceModels "github.com/fastenhealth/fasten-sources/clients/models"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )

--- a/backend/pkg/web/handler/resource_fhir.go
+++ b/backend/pkg/web/handler/resource_fhir.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -9,6 +11,7 @@ import (
 	"github.com/fastenhealth/fasten-onprem/backend/pkg"
 	"github.com/fastenhealth/fasten-onprem/backend/pkg/database"
 	"github.com/fastenhealth/fasten-onprem/backend/pkg/models"
+	sourceModels "github.com/fastenhealth/fasten-sources/clients/models"
 	"github.com/fastenhealth/fasten-onprem/backend/pkg/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -147,6 +150,79 @@ func UpdateResourceFhir(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"success": true})
+}
+
+// UpdateResourceFhirByType updates a resource looked up by resource type and resource ID.
+// Used by the medical record wizard's edit modals.
+func UpdateResourceFhirByType(c *gin.Context) {
+	databaseRepo := c.MustGet(pkg.ContextKeyTypeDatabase).(database.DatabaseRepository)
+
+	resourceType := strings.Trim(c.Param("resourceType"), "/")
+	resourceId := strings.Trim(c.Param("resourceId"), "/")
+
+	type UpdatePayload struct {
+		ResourceRaw json.RawMessage `json:"resource_raw"`
+		SortTitle   string          `json:"sort_title"`
+		SortDate    string          `json:"sort_date"`
+	}
+	var payload UpdatePayload
+	err := c.ShouldBindJSON(&payload)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "invalid request payload"})
+		return
+	}
+
+	resource, err := databaseRepo.GetResourceByResourceTypeAndId(c, resourceType, resourceId)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "could not find resource"})
+		return
+	}
+
+	sourceCredential, err := databaseRepo.GetSource(c, resource.SourceID.String())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "could not find Fasten source for resource"})
+		return
+	}
+
+	resourceToUpsert := sourceModels.RawResourceFhir{
+		SourceResourceType: resourceType,
+		SourceResourceID:   resourceId,
+		ResourceRaw:        payload.ResourceRaw,
+		SortTitle:          &payload.SortTitle,
+		SortDate:           parseDateTimeWithFallback(&payload.SortDate),
+	}
+
+	_, updateError := databaseRepo.UpsertRawResource(c, sourceCredential, resourceToUpsert)
+	if updateError != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "failed to update resource"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}
+
+// DeleteResourceFhirByType deletes a resource looked up by resource type and resource ID.
+// Used by the practitioner list/view pages.
+func DeleteResourceFhirByType(c *gin.Context) {
+	databaseRepo := c.MustGet(pkg.ContextKeyTypeDatabase).(database.DatabaseRepository)
+
+	resourceType := strings.Trim(c.Param("resourceType"), "/")
+	resourceId := strings.Trim(c.Param("resourceId"), "/")
+
+	deleteError := databaseRepo.DeleteResourceByTypeAndId(c, resourceType, resourceId)
+	if deleteError != nil {
+		fmt.Printf("Delete operation failed: %v\n", deleteError)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success":       false,
+			"error":         "failed to delete resource",
+			"details":       deleteError.Error(),
+			"resource_type": resourceType,
+			"resource_id":   resourceId,
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true, "message": "resource deleted successfully"})
 }
 
 // deprecated - using Manual Resource Wizard instead

--- a/backend/pkg/web/handler/resource_fhir.go
+++ b/backend/pkg/web/handler/resource_fhir.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -12,7 +10,6 @@ import (
 	"github.com/fastenhealth/fasten-onprem/backend/pkg/database"
 	"github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	"github.com/fastenhealth/fasten-onprem/backend/pkg/utils"
-	sourceModels "github.com/fastenhealth/fasten-sources/clients/models"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )
@@ -99,6 +96,59 @@ func GetResourceFhir(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"success": true, "data": wrappedResourceModel})
 }
 
+func DeleteResourceFhir(c *gin.Context) {
+	logger := c.MustGet(pkg.ContextKeyTypeLogger).(*logrus.Entry)
+	databaseRepo := c.MustGet(pkg.ContextKeyTypeDatabase).(database.DatabaseRepository)
+
+	sourceId := strings.Trim(c.Param("sourceId"), "/")
+	resourceId := strings.Trim(c.Param("resourceId"), "/")
+
+	rowsAffected, err := databaseRepo.DeleteResourceBySourceId(c, sourceId, resourceId)
+	if err != nil {
+		if strings.Contains(err.Error(), "resource not found") {
+			c.JSON(http.StatusNotFound, gin.H{"success": false, "error": err.Error()})
+			return
+		} else if strings.Contains(err.Error(), "only allowed for manual") {
+			c.JSON(http.StatusForbidden, gin.H{"success": false, "error": err.Error()})
+			return
+		}
+		logger.Errorln("An error occurred while deleting resource", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": rowsAffected})
+}
+
+func UpdateResourceFhir(c *gin.Context) {
+	logger := c.MustGet(pkg.ContextKeyTypeLogger).(*logrus.Entry)
+	databaseRepo := c.MustGet(pkg.ContextKeyTypeDatabase).(database.DatabaseRepository)
+
+	sourceId := strings.Trim(c.Param("sourceId"), "/")
+	resourceId := strings.Trim(c.Param("resourceId"), "/")
+
+	var requestBody models.ResourceBase
+	if err := c.ShouldBindJSON(&requestBody); err != nil {
+		logger.Errorln("An error occurred while parsing request body", err)
+		c.JSON(http.StatusBadRequest, gin.H{"success": false})
+		return
+	}
+
+	err := databaseRepo.UpdateResourceBySourceId(c, sourceId, resourceId, requestBody.ResourceRaw)
+	if err != nil {
+		if strings.Contains(err.Error(), "resource not found") {
+			c.JSON(http.StatusNotFound, gin.H{"success": false, "error": err.Error()})
+			return
+		} else if strings.Contains(err.Error(), "only allowed for manual") {
+			c.JSON(http.StatusForbidden, gin.H{"success": false, "error": err.Error()})
+			return
+		}
+		logger.Errorln("An error occurred while updating resource", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}
+
 // deprecated - using Manual Resource Wizard instead
 func CreateResourceComposition(c *gin.Context) {
 
@@ -158,75 +208,6 @@ func GetResourceFhirGraph(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"success": true, "data": map[string]interface{}{
 		"results": resourceListDictionary,
 	}})
-}
-
-func UpdateResourceFhir(c *gin.Context) {
-	databaseRepo := c.MustGet(pkg.ContextKeyTypeDatabase).(database.DatabaseRepository)
-
-	resourceType := strings.Trim(c.Param("resourceType"), "/")
-	resourceId := strings.Trim(c.Param("resourceId"), "/")
-
-	type UpdatePayload struct {
-		ResourceRaw json.RawMessage `json:"resource_raw"`
-		SortTitle   string          `json:"sort_title"`
-		SortDate    string          `json:"sort_date"`
-	}
-	var payload UpdatePayload
-	err := c.ShouldBindJSON(&payload)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "invalid request payload"})
-		return
-	}
-
-	resource, err := databaseRepo.GetResourceByResourceTypeAndId(c, resourceType, resourceId)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "could not find resource"})
-		return
-	}
-
-	sourceCredential, err := databaseRepo.GetSource(c, resource.SourceID.String())
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "could not find Fasten source for resource"})
-		return
-	}
-
-	resourceToUpsert := sourceModels.RawResourceFhir{
-		SourceResourceType: resourceType,
-		SourceResourceID:   resourceId,
-		ResourceRaw:        payload.ResourceRaw,
-		SortTitle:          &payload.SortTitle,
-		SortDate:           parseDateTimeWithFallback(&payload.SortDate),
-	}
-
-	_, updateError := databaseRepo.UpsertRawResource(c, sourceCredential, resourceToUpsert)
-	if updateError != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "failed to update resource"})
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{"success": true})
-}
-
-func DeleteResourceFhir(c *gin.Context) {
-	databaseRepo := c.MustGet(pkg.ContextKeyTypeDatabase).(database.DatabaseRepository)
-
-	resourceType := strings.Trim(c.Param("resourceType"), "/")
-	resourceId := strings.Trim(c.Param("resourceId"), "/")
-
-	deleteError := databaseRepo.DeleteResourceByTypeAndId(c, resourceType, resourceId)
-	if deleteError != nil {
-		fmt.Printf("Delete operation failed: %v\n", deleteError)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"success":       false,
-			"error":         "failed to delete resource",
-			"details":       deleteError.Error(),
-			"resource_type": resourceType,
-			"resource_id":   resourceId,
-		})
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{"success": true, "message": "resource deleted successfully"})
 }
 
 func parseDateTimeWithFallback(dateTime *string) *time.Time {

--- a/backend/pkg/web/handler/resource_fhir_test.go
+++ b/backend/pkg/web/handler/resource_fhir_test.go
@@ -386,7 +386,7 @@ func (suite *ResourceFhirHandlerTestSuite) TestListResourceFhirHandler_WithInval
         },
 	})
 	suite.NoError(err)
-	
+
 	ListResourceFhir(ctx)
 
 	type ResponseWrapper struct {
@@ -400,4 +400,116 @@ func (suite *ResourceFhirHandlerTestSuite) TestListResourceFhirHandler_WithInval
 	require.Equal(suite.T(), false, respWrapper.Success)
 	require.Empty(suite.T(), respWrapper.Data)
 
+}
+
+func (suite *ResourceFhirHandlerTestSuite) TestDeleteResourceFhirHandler() {
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	setupGinContext(ctx, suite)
+
+	ctx.AddParam("sourceId", suite.SourceId.String())
+	ctx.AddParam("resourceId", "57959813-8cd2-4e3c-8970-e4364b74980a")
+
+	req, err := http.NewRequest("DELETE", fhirResourcePath, &bytes.Buffer{})
+	require.NoError(suite.T(), err)
+	ctx.Request = req
+
+	DeleteResourceFhir(ctx)
+
+	type ResponseWrapper struct {
+		Data    int64 `json:"data"`
+		Success bool  `json:"success"`
+	}
+	var respWrapper ResponseWrapper
+	err = json.Unmarshal(w.Body.Bytes(), &respWrapper)
+	require.NoError(suite.T(), err)
+	require.Equal(suite.T(), true, respWrapper.Success)
+	require.Equal(suite.T(), int64(1), respWrapper.Data)
+
+	// verify resource is no longer found
+	w2 := httptest.NewRecorder()
+	ctx2, _ := gin.CreateTestContext(w2)
+	setupGinContext(ctx2, suite)
+	ctx2.AddParam("sourceId", suite.SourceId.String())
+	ctx2.AddParam("resourceId", "57959813-8cd2-4e3c-8970-e4364b74980a")
+
+	GetResourceFhir(ctx2)
+	require.Equal(suite.T(), http.StatusInternalServerError, w2.Code)
+}
+
+func (suite *ResourceFhirHandlerTestSuite) TestDeleteResourceFhirHandler_WithInvalidResourceId() {
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	setupGinContext(ctx, suite)
+
+	ctx.AddParam("sourceId", suite.SourceId.String())
+	ctx.AddParam("resourceId", "does-not-exist")
+
+	req, err := http.NewRequest("DELETE", fhirResourcePath, &bytes.Buffer{})
+	require.NoError(suite.T(), err)
+	ctx.Request = req
+
+	DeleteResourceFhir(ctx)
+
+	require.Equal(suite.T(), http.StatusNotFound, w.Code)
+}
+
+func (suite *ResourceFhirHandlerTestSuite) TestUpdateResourceFhirHandler() {
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	setupGinContext(ctx, suite)
+
+	ctx.AddParam("sourceId", suite.SourceId.String())
+	ctx.AddParam("resourceId", "cd72a003-ffa9-44a2-9e9c-97004144f5d8")
+
+	updateBody, err := json.Marshal(map[string]interface{}{
+		"resource_raw": map[string]interface{}{
+			"resourceType": "Observation",
+			"id":           "cd72a003-ffa9-44a2-9e9c-97004144f5d8",
+			"status":       "amended",
+		},
+	})
+	require.NoError(suite.T(), err)
+
+	req, err := http.NewRequest("PUT", fhirResourcePath, bytes.NewBuffer(updateBody))
+	require.NoError(suite.T(), err)
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+
+	UpdateResourceFhir(ctx)
+
+	type ResponseWrapper struct {
+		Success bool `json:"success"`
+	}
+	var respWrapper ResponseWrapper
+	err = json.Unmarshal(w.Body.Bytes(), &respWrapper)
+	require.NoError(suite.T(), err)
+	require.Equal(suite.T(), true, respWrapper.Success)
+}
+
+func (suite *ResourceFhirHandlerTestSuite) TestUpdateResourceFhirHandler_WithInvalidResourceId() {
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	setupGinContext(ctx, suite)
+
+	ctx.AddParam("sourceId", suite.SourceId.String())
+	ctx.AddParam("resourceId", "does-not-exist")
+
+	updateBody, err := json.Marshal(map[string]interface{}{
+		"resource_raw": map[string]interface{}{
+			"resourceType": "Observation",
+			"id":           "does-not-exist",
+			"status":       "amended",
+		},
+	})
+	require.NoError(suite.T(), err)
+
+	req, err := http.NewRequest("PUT", fhirResourcePath, bytes.NewBuffer(updateBody))
+	require.NoError(suite.T(), err)
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+
+	UpdateResourceFhir(ctx)
+
+	require.Equal(suite.T(), http.StatusNotFound, w.Code)
 }

--- a/backend/pkg/web/handler/resource_fhir_test.go
+++ b/backend/pkg/web/handler/resource_fhir_test.go
@@ -38,6 +38,7 @@ type ResourceFhirHandlerTestSuite struct {
 	AppEventBus   event_bus.Interface
 	SourceId      uuid.UUID
 }
+
 func setupGinContext(ctx *gin.Context, suite *ResourceFhirHandlerTestSuite) {
 	ctx.Set(pkg.ContextKeyTypeLogger, logrus.WithField("test", suite.T().Name()))
 	ctx.Set(pkg.ContextKeyTypeDatabase, suite.AppRepository)
@@ -46,9 +47,9 @@ func setupGinContext(ctx *gin.Context, suite *ResourceFhirHandlerTestSuite) {
 	ctx.Set(pkg.ContextKeyTypeAuthUsername, "test_user")
 }
 
-func addParamsToGinContext(ctx *gin.Context,params []gin.Param) error {
-	var baseUrl = fhirResourcePath +  "?"
-	for i,param  := range params {
+func addParamsToGinContext(ctx *gin.Context, params []gin.Param) error {
+	var baseUrl = fhirResourcePath + "?"
+	for i, param := range params {
 		if i > 0 {
 			baseUrl += "&"
 		}
@@ -56,17 +57,17 @@ func addParamsToGinContext(ctx *gin.Context,params []gin.Param) error {
 	}
 	body := &bytes.Buffer{}
 	req, err := http.NewRequest("GET", baseUrl, body)
-	if err!= nil {
-        log.Fatal("Could not make http request ", err.Error())
+	if err != nil {
+		log.Fatal("Could not make http request ", err.Error())
 		return err
 	}
 	ctx.Request = req
 	return nil
 }
 
-//SetupAllSuite has a SetupSuite method, which will run before the tests in the suite are run.
+// SetupAllSuite has a SetupSuite method, which will run before the tests in the suite are run.
 func (suite *ResourceFhirHandlerTestSuite) SetupSuite() {
-	suiteName  := suite.T().Name()
+	suiteName := suite.T().Name()
 	suite.MockCtrl = gomock.NewController(suite.T())
 
 	// ioutils is deprecated, used os.CreateTemp
@@ -92,7 +93,7 @@ func (suite *ResourceFhirHandlerTestSuite) SetupSuite() {
 	appRepo.CreateUser(context.Background(), &models.User{
 		Username: "test_user",
 		Password: "test",
-	})	
+	})
 	//Pre adding the source data
 	w := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(w)
@@ -131,11 +132,10 @@ func TestResourceHandlerTestSuite(t *testing.T) {
 	suite.Run(t, new(ResourceFhirHandlerTestSuite))
 }
 
-
 func (suite *ResourceFhirHandlerTestSuite) TestGetResourceFhirHandler() {
 	w := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(w)
-	setupGinContext(ctx,suite)
+	setupGinContext(ctx, suite)
 
 	ctx.AddParam("sourceId", suite.SourceId.String())
 	ctx.AddParam("resourceId", "57959813-8cd2-4e3c-8970-e4364b74980a")
@@ -159,7 +159,7 @@ func (suite *ResourceFhirHandlerTestSuite) TestGetResourceFhirHandler() {
 func (suite *ResourceFhirHandlerTestSuite) TestGetResourceFhirHandler_WithInvalidSourceResourceId() {
 	w := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(w)
-	setupGinContext(ctx,suite)
+	setupGinContext(ctx, suite)
 
 	ctx.AddParam("sourceId", "-1")
 	ctx.AddParam("resourceId", "57959813-9999-4e3c-8970-e4364b74980a")
@@ -172,23 +172,23 @@ func (suite *ResourceFhirHandlerTestSuite) TestGetResourceFhirHandler_WithInvali
 	}
 	var respWrapper ResponseWrapper
 	err := json.Unmarshal(w.Body.Bytes(), &respWrapper)
-	require.NoError(suite.T(),err)
-	
-	require.Equal(suite.T(),false,respWrapper.Success)
-	require.Nil(suite.T(),respWrapper.Data)
-	
+	require.NoError(suite.T(), err)
+
+	require.Equal(suite.T(), false, respWrapper.Success)
+	require.Nil(suite.T(), respWrapper.Data)
+
 }
 
 func (suite *ResourceFhirHandlerTestSuite) TestListResourceFhirHandler_WithValidSourceResourceId() {
 	w := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(w)
 	setupGinContext(ctx, suite)
-	
-	err := addParamsToGinContext(ctx, []gin.Param {
+
+	err := addParamsToGinContext(ctx, []gin.Param{
 		{
-            Key: "sourceResourceID",
-            Value: "cd72a003-ffa9-44a2-9e9c-97004144f5d8",
-        },
+			Key:   "sourceResourceID",
+			Value: "cd72a003-ffa9-44a2-9e9c-97004144f5d8",
+		},
 	})
 	suite.NoError(err)
 
@@ -212,10 +212,10 @@ func (suite *ResourceFhirHandlerTestSuite) TestListResourceFhirHandler_WithValid
 	ctx, _ := gin.CreateTestContext(w)
 	setupGinContext(ctx, suite)
 
-	err := addParamsToGinContext(ctx, []gin.Param {
+	err := addParamsToGinContext(ctx, []gin.Param{
 		{
-			Key: "sourceResourceType",
-            Value: "Patient",
+			Key:   "sourceResourceType",
+			Value: "Patient",
 		},
 	})
 	suite.NoError(err)
@@ -240,10 +240,10 @@ func (suite *ResourceFhirHandlerTestSuite) TestListResourceFhirHandler_WithInVal
 	ctx, _ := gin.CreateTestContext(w)
 	setupGinContext(ctx, suite)
 
-	err := addParamsToGinContext(ctx, []gin.Param {
+	err := addParamsToGinContext(ctx, []gin.Param{
 		{
-			Key: "sourceResourceType",
-            Value: "org",
+			Key:   "sourceResourceType",
+			Value: "org",
 		},
 	})
 	suite.NoError(err)
@@ -257,9 +257,8 @@ func (suite *ResourceFhirHandlerTestSuite) TestListResourceFhirHandler_WithInVal
 	err = json.Unmarshal(w.Body.Bytes(), &respWrapper)
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), false, respWrapper.Success)
-	require.Empty(suite.T(),respWrapper.Data)
+	require.Empty(suite.T(), respWrapper.Data)
 }
-
 
 func (suite *ResourceFhirHandlerTestSuite) TestListResourceFhirHandler_WithValidSourceIdAndPageAndSort() {
 	w := httptest.NewRecorder()
@@ -268,14 +267,14 @@ func (suite *ResourceFhirHandlerTestSuite) TestListResourceFhirHandler_WithValid
 
 	err := addParamsToGinContext(ctx, []gin.Param{
 		{
-            Key: "sourceID",
-            Value: suite.SourceId.String(),
-        },
+			Key:   "sourceID",
+			Value: suite.SourceId.String(),
+		},
 		{
-			Key: "page",
+			Key:   "page",
 			Value: "2",
 		},
-    })
+	})
 	suite.NoError(err)
 
 	ListResourceFhir(ctx)
@@ -306,23 +305,22 @@ func (suite *ResourceFhirHandlerTestSuite) TestListResourceFhirHandler_SortingBy
 	ctx, _ := gin.CreateTestContext(w)
 	setupGinContext(ctx, suite)
 
-
-	err := addParamsToGinContext(ctx, []gin.Param {
+	err := addParamsToGinContext(ctx, []gin.Param{
 		{
-            Key: "sortBy",
-            Value: "title",
-        },
+			Key:   "sortBy",
+			Value: "title",
+		},
 		{
-            Key: "page",
-            Value: "2",
-        },
+			Key:   "page",
+			Value: "2",
+		},
 		{
-            Key: "sourceID",
-            Value: suite.SourceId.String(),
-        },
+			Key:   "sourceID",
+			Value: suite.SourceId.String(),
+		},
 	})
 	suite.NoError(err)
-	
+
 	ListResourceFhir(ctx)
 
 	type ResponseWrapper struct {
@@ -346,19 +344,19 @@ func (suite *ResourceFhirHandlerTestSuite) TestListResourceFhirHandler_WithInval
 	w := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(w)
 	setupGinContext(ctx, suite)
- 
-	err := addParamsToGinContext(ctx, []gin.Param {
+
+	err := addParamsToGinContext(ctx, []gin.Param{
 		{
-			Key: "sourceID",
+			Key:   "sourceID",
 			Value: "-1",
 		},
 		{
-			Key: "resourceID",
+			Key:   "resourceID",
 			Value: "-1",
 		},
 	})
 	suite.NoError(err)
-	
+
 	ListResourceFhir(ctx)
 
 	type ResponseWrapper struct {
@@ -379,11 +377,11 @@ func (suite *ResourceFhirHandlerTestSuite) TestListResourceFhirHandler_WithInval
 	ctx, _ := gin.CreateTestContext(w)
 	setupGinContext(ctx, suite)
 
-	err := addParamsToGinContext(ctx, []gin.Param {
+	err := addParamsToGinContext(ctx, []gin.Param{
 		{
-            Key: "page",
-            Value: "page",
-        },
+			Key:   "page",
+			Value: "page",
+		},
 	})
 	suite.NoError(err)
 

--- a/backend/pkg/web/server.go
+++ b/backend/pkg/web/server.go
@@ -176,8 +176,8 @@ func (ae *AppEngine) Setup() (*gin.RouterGroup, *gin.Engine) {
 					secure.GET("/resource/fhir", handler.ListResourceFhir)
 					secure.POST("/resource/graph/:graphType", handler.GetResourceFhirGraph)
 					secure.GET("/resource/fhir/:sourceId/:resourceId", handler.GetResourceFhir)
-					secure.PATCH("/resource/fhir/:resourceType/:resourceId", handler.UpdateResourceFhir)
-					secure.DELETE("/resource/fhir/:resourceType/:resourceId", handler.DeleteResourceFhir)
+					secure.DELETE("/resource/fhir/:sourceId/:resourceId", handler.DeleteResourceFhir)
+					secure.PUT("/resource/fhir/:sourceId/:resourceId", handler.UpdateResourceFhir)
 
 					secure.POST("/resource/composition", handler.CreateResourceComposition)
 					secure.POST("/resource/related", handler.CreateRelatedResources)

--- a/backend/pkg/web/server.go
+++ b/backend/pkg/web/server.go
@@ -26,10 +26,10 @@ import (
 )
 
 type AppEngine struct {
-	Config     config.Interface
-	Logger     *logrus.Entry
-	EventBus   event_bus.Interface
-	deviceRepo database.DatabaseRepository
+	Config      config.Interface
+	Logger      *logrus.Entry
+	EventBus    event_bus.Interface
+	deviceRepo  database.DatabaseRepository
 	StandbyMode bool
 
 	RelatedVersions map[string]string //related versions metadata provided & embedded by the build process
@@ -99,8 +99,8 @@ func (ae *AppEngine) Setup() (*gin.RouterGroup, *gin.Engine) {
 					c.JSON(http.StatusOK, gin.H{
 						"success": true,
 						"data": gin.H{
-							"first_run_wizard":   firstRunWizard,
-							"standby_mode":       true,
+							"first_run_wizard": firstRunWizard,
+							"standby_mode":     true,
 						},
 					})
 					return
@@ -125,8 +125,8 @@ func (ae *AppEngine) Setup() (*gin.RouterGroup, *gin.Engine) {
 				c.JSON(http.StatusOK, gin.H{
 					"success": true,
 					"data": gin.H{
-						"first_run_wizard":   firstRunWizard,
-						"standby_mode":       false,
+						"first_run_wizard": firstRunWizard,
+						"standby_mode":     false,
 					},
 				})
 			})

--- a/backend/pkg/web/server.go
+++ b/backend/pkg/web/server.go
@@ -178,6 +178,8 @@ func (ae *AppEngine) Setup() (*gin.RouterGroup, *gin.Engine) {
 					secure.GET("/resource/fhir/:sourceId/:resourceId", handler.GetResourceFhir)
 					secure.DELETE("/resource/fhir/:sourceId/:resourceId", handler.DeleteResourceFhir)
 					secure.PUT("/resource/fhir/:sourceId/:resourceId", handler.UpdateResourceFhir)
+					secure.PATCH("/resource/fhir/:resourceType/:resourceId", handler.UpdateResourceFhirByType)
+					secure.DELETE("/resource/fhir-by-type/:resourceType/:resourceId", handler.DeleteResourceFhirByType)
 
 					secure.POST("/resource/composition", handler.CreateResourceComposition)
 					secure.POST("/resource/related", handler.CreateRelatedResources)

--- a/frontend/src/app/components/resource-edit/resource-edit.component.html
+++ b/frontend/src/app/components/resource-edit/resource-edit.component.html
@@ -1,0 +1,280 @@
+<form [formGroup]="form" (ngSubmit)="onSubmit()">
+  <div class="modal-header">
+    <h4 class="modal-title">Edit {{resourceType}}</h4>
+    <button type="button" class="btn close" aria-label="Close" (click)="activeModal.dismiss()">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+
+  <div class="modal-body">
+    <div class="mb-3 text-muted">
+      <strong>{{getResourceDisplayName()}}</strong>
+    </div>
+
+    <!-- Condition -->
+    <ng-container *ngIf="resourceType === 'Condition'">
+      <div class="form-group mb-3">
+        <label for="clinicalStatus">Clinical Status</label>
+        <select class="form-control" id="clinicalStatus" formControlName="clinicalStatus">
+          <option value="active">active</option>
+          <option value="inactive">inactive</option>
+          <option value="resolved">resolved</option>
+          <option value="remission">remission</option>
+          <option value="recurrence">recurrence</option>
+          <option value="relapse">relapse</option>
+        </select>
+      </div>
+      <div class="form-group mb-3">
+        <label for="onsetDateTime">Onset Date</label>
+        <div class="input-group">
+          <input class="form-control" id="onsetDateTime" formControlName="onsetDateTime"
+                 ngbDatepicker #onsetDp="ngbDatepicker" placeholder="yyyy-mm-dd"/>
+          <button class="btn btn-outline-secondary" (click)="onsetDp.toggle()" type="button">
+            <i class="fas fa-calendar"></i>
+          </button>
+        </div>
+      </div>
+      <div class="form-group mb-3">
+        <label for="abatementDateTime">Abatement Date</label>
+        <div class="input-group">
+          <input class="form-control" id="abatementDateTime" formControlName="abatementDateTime"
+                 ngbDatepicker #abatementDp="ngbDatepicker" placeholder="yyyy-mm-dd"/>
+          <button class="btn btn-outline-secondary" (click)="abatementDp.toggle()" type="button">
+            <i class="fas fa-calendar"></i>
+          </button>
+        </div>
+      </div>
+      <div class="form-group mb-3">
+        <label for="conditionNote">Notes</label>
+        <textarea class="form-control" id="conditionNote" formControlName="note" rows="3"></textarea>
+      </div>
+    </ng-container>
+
+    <!-- Observation -->
+    <ng-container *ngIf="resourceType === 'Observation'">
+      <div class="form-group mb-3">
+        <label for="obsStatus">Status</label>
+        <select class="form-control" id="obsStatus" formControlName="status">
+          <option value="registered">registered</option>
+          <option value="preliminary">preliminary</option>
+          <option value="final">final</option>
+          <option value="amended">amended</option>
+          <option value="corrected">corrected</option>
+          <option value="cancelled">cancelled</option>
+          <option value="entered-in-error">entered-in-error</option>
+        </select>
+      </div>
+      <div class="form-group mb-3">
+        <label for="effectiveDateTime">Effective Date</label>
+        <div class="input-group">
+          <input class="form-control" id="effectiveDateTime" formControlName="effectiveDateTime"
+                 ngbDatepicker #effectiveDp="ngbDatepicker" placeholder="yyyy-mm-dd"/>
+          <button class="btn btn-outline-secondary" (click)="effectiveDp.toggle()" type="button">
+            <i class="fas fa-calendar"></i>
+          </button>
+        </div>
+      </div>
+      <ng-container *ngIf="hasValueQuantity()">
+        <div class="form-group mb-3">
+          <label for="valueQuantityValue">Value</label>
+          <div class="input-group">
+            <input type="number" class="form-control" id="valueQuantityValue" formControlName="valueQuantityValue"/>
+            <input type="text" class="form-control" formControlName="valueQuantityUnit" placeholder="unit"/>
+          </div>
+        </div>
+      </ng-container>
+      <ng-container *ngIf="hasValueString()">
+        <div class="form-group mb-3">
+          <label for="valueString">Value</label>
+          <input type="text" class="form-control" id="valueString" formControlName="valueString"/>
+        </div>
+      </ng-container>
+      <div class="form-group mb-3">
+        <label for="obsNote">Notes</label>
+        <textarea class="form-control" id="obsNote" formControlName="note" rows="3"></textarea>
+      </div>
+    </ng-container>
+
+    <!-- MedicationRequest -->
+    <ng-container *ngIf="resourceType === 'MedicationRequest'">
+      <div class="form-group mb-3">
+        <label for="medStatus">Status</label>
+        <select class="form-control" id="medStatus" formControlName="status">
+          <option value="active">active</option>
+          <option value="on-hold">on-hold</option>
+          <option value="cancelled">cancelled</option>
+          <option value="completed">completed</option>
+          <option value="entered-in-error">entered-in-error</option>
+          <option value="stopped">stopped</option>
+          <option value="draft">draft</option>
+        </select>
+      </div>
+      <div class="form-group mb-3">
+        <label for="intent">Intent</label>
+        <select class="form-control" id="intent" formControlName="intent">
+          <option value="proposal">proposal</option>
+          <option value="plan">plan</option>
+          <option value="order">order</option>
+          <option value="original-order">original-order</option>
+          <option value="reflex-order">reflex-order</option>
+          <option value="filler-order">filler-order</option>
+          <option value="instance-order">instance-order</option>
+          <option value="option">option</option>
+        </select>
+      </div>
+      <div class="form-group mb-3">
+        <label for="authoredOn">Authored On</label>
+        <div class="input-group">
+          <input class="form-control" id="authoredOn" formControlName="authoredOn"
+                 ngbDatepicker #authoredOnDp="ngbDatepicker" placeholder="yyyy-mm-dd"/>
+          <button class="btn btn-outline-secondary" (click)="authoredOnDp.toggle()" type="button">
+            <i class="fas fa-calendar"></i>
+          </button>
+        </div>
+      </div>
+      <div class="form-group mb-3">
+        <label for="dosage">Dosage</label>
+        <input type="text" class="form-control" id="dosage" formControlName="dosage"/>
+      </div>
+      <div class="form-group mb-3">
+        <label for="medNote">Notes</label>
+        <textarea class="form-control" id="medNote" formControlName="note" rows="3"></textarea>
+      </div>
+    </ng-container>
+
+    <!-- Encounter -->
+    <ng-container *ngIf="resourceType === 'Encounter'">
+      <div class="form-group mb-3">
+        <label for="encStatus">Status</label>
+        <select class="form-control" id="encStatus" formControlName="status">
+          <option value="planned">planned</option>
+          <option value="arrived">arrived</option>
+          <option value="triaged">triaged</option>
+          <option value="in-progress">in-progress</option>
+          <option value="onleave">onleave</option>
+          <option value="finished">finished</option>
+          <option value="cancelled">cancelled</option>
+        </select>
+      </div>
+      <div class="form-group mb-3">
+        <label for="periodStart">Period Start</label>
+        <div class="input-group">
+          <input class="form-control" id="periodStart" formControlName="periodStart"
+                 ngbDatepicker #periodStartDp="ngbDatepicker" placeholder="yyyy-mm-dd"/>
+          <button class="btn btn-outline-secondary" (click)="periodStartDp.toggle()" type="button">
+            <i class="fas fa-calendar"></i>
+          </button>
+        </div>
+      </div>
+      <div class="form-group mb-3">
+        <label for="periodEnd">Period End</label>
+        <div class="input-group">
+          <input class="form-control" id="periodEnd" formControlName="periodEnd"
+                 ngbDatepicker #periodEndDp="ngbDatepicker" placeholder="yyyy-mm-dd"/>
+          <button class="btn btn-outline-secondary" (click)="periodEndDp.toggle()" type="button">
+            <i class="fas fa-calendar"></i>
+          </button>
+        </div>
+      </div>
+    </ng-container>
+
+    <!-- AllergyIntolerance -->
+    <ng-container *ngIf="resourceType === 'AllergyIntolerance'">
+      <div class="form-group mb-3">
+        <label for="allergyStatus">Clinical Status</label>
+        <select class="form-control" id="allergyStatus" formControlName="clinicalStatus">
+          <option value="active">active</option>
+          <option value="inactive">inactive</option>
+          <option value="resolved">resolved</option>
+        </select>
+      </div>
+      <div class="form-group mb-3">
+        <label for="category">Category</label>
+        <select class="form-control" id="category" formControlName="category">
+          <option value="food">food</option>
+          <option value="medication">medication</option>
+          <option value="environment">environment</option>
+          <option value="biologic">biologic</option>
+        </select>
+      </div>
+      <div class="form-group mb-3">
+        <label for="recordedDate">Recorded Date</label>
+        <div class="input-group">
+          <input class="form-control" id="recordedDate" formControlName="recordedDate"
+                 ngbDatepicker #recordedDateDp="ngbDatepicker" placeholder="yyyy-mm-dd"/>
+          <button class="btn btn-outline-secondary" (click)="recordedDateDp.toggle()" type="button">
+            <i class="fas fa-calendar"></i>
+          </button>
+        </div>
+      </div>
+      <div class="form-group mb-3">
+        <label for="allergyNote">Notes</label>
+        <textarea class="form-control" id="allergyNote" formControlName="note" rows="3"></textarea>
+      </div>
+    </ng-container>
+
+    <!-- Procedure -->
+    <ng-container *ngIf="resourceType === 'Procedure'">
+      <div class="form-group mb-3">
+        <label for="procStatus">Status</label>
+        <select class="form-control" id="procStatus" formControlName="status">
+          <option value="preparation">preparation</option>
+          <option value="in-progress">in-progress</option>
+          <option value="not-done">not-done</option>
+          <option value="on-hold">on-hold</option>
+          <option value="stopped">stopped</option>
+          <option value="completed">completed</option>
+          <option value="entered-in-error">entered-in-error</option>
+        </select>
+      </div>
+      <div class="form-group mb-3">
+        <label for="performedDateTime">Performed Date</label>
+        <div class="input-group">
+          <input class="form-control" id="performedDateTime" formControlName="performedDateTime"
+                 ngbDatepicker #performedDp="ngbDatepicker" placeholder="yyyy-mm-dd"/>
+          <button class="btn btn-outline-secondary" (click)="performedDp.toggle()" type="button">
+            <i class="fas fa-calendar"></i>
+          </button>
+        </div>
+      </div>
+      <div class="form-group mb-3">
+        <label for="procNote">Notes</label>
+        <textarea class="form-control" id="procNote" formControlName="note" rows="3"></textarea>
+      </div>
+    </ng-container>
+
+    <!-- Immunization -->
+    <ng-container *ngIf="resourceType === 'Immunization'">
+      <div class="form-group mb-3">
+        <label for="immunStatus">Status</label>
+        <select class="form-control" id="immunStatus" formControlName="status">
+          <option value="completed">completed</option>
+          <option value="entered-in-error">entered-in-error</option>
+          <option value="not-done">not-done</option>
+        </select>
+      </div>
+      <div class="form-group mb-3">
+        <label for="occurrenceDateTime">Occurrence Date</label>
+        <div class="input-group">
+          <input class="form-control" id="occurrenceDateTime" formControlName="occurrenceDateTime"
+                 ngbDatepicker #occurrenceDp="ngbDatepicker" placeholder="yyyy-mm-dd"/>
+          <button class="btn btn-outline-secondary" (click)="occurrenceDp.toggle()" type="button">
+            <i class="fas fa-calendar"></i>
+          </button>
+        </div>
+      </div>
+      <div class="form-group mb-3">
+        <label for="immunNote">Notes</label>
+        <textarea class="form-control" id="immunNote" formControlName="note" rows="3"></textarea>
+      </div>
+    </ng-container>
+  </div>
+
+  <div class="modal-footer">
+    <button type="button" class="btn btn-outline-light" (click)="activeModal.dismiss()">Cancel</button>
+    <button type="submit" class="btn btn-indigo" [disabled]="saving">
+      <span *ngIf="saving" class="spinner-border spinner-border-sm mr-1"></span>
+      Save Changes
+    </button>
+  </div>
+</form>

--- a/frontend/src/app/components/resource-edit/resource-edit.component.html
+++ b/frontend/src/app/components/resource-edit/resource-edit.component.html
@@ -1,21 +1,30 @@
 <form [formGroup]="form" (ngSubmit)="onSubmit()">
   <div class="modal-header">
-    <h4 class="modal-title">Edit {{resourceType}}</h4>
-    <button type="button" class="btn close" aria-label="Close" (click)="activeModal.dismiss()">
+    <h4 class="modal-title">Edit {{ resourceType }}</h4>
+    <button
+      type="button"
+      class="btn close"
+      aria-label="Close"
+      (click)="activeModal.dismiss()"
+    >
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
 
   <div class="modal-body">
     <div class="mb-3 text-muted">
-      <strong>{{getResourceDisplayName()}}</strong>
+      <strong>{{ getResourceDisplayName() }}</strong>
     </div>
 
     <!-- Condition -->
     <ng-container *ngIf="resourceType === 'Condition'">
       <div class="form-group mb-3">
         <label for="clinicalStatus">Clinical Status</label>
-        <select class="form-control" id="clinicalStatus" formControlName="clinicalStatus">
+        <select
+          class="form-control"
+          id="clinicalStatus"
+          formControlName="clinicalStatus"
+        >
           <option value="active">active</option>
           <option value="inactive">inactive</option>
           <option value="resolved">resolved</option>
@@ -27,9 +36,19 @@
       <div class="form-group mb-3">
         <label for="onsetDateTime">Onset Date</label>
         <div class="input-group">
-          <input class="form-control" id="onsetDateTime" formControlName="onsetDateTime"
-                 ngbDatepicker #onsetDp="ngbDatepicker" placeholder="yyyy-mm-dd"/>
-          <button class="btn btn-outline-secondary" (click)="onsetDp.toggle()" type="button">
+          <input
+            class="form-control"
+            id="onsetDateTime"
+            formControlName="onsetDateTime"
+            ngbDatepicker
+            #onsetDp="ngbDatepicker"
+            placeholder="yyyy-mm-dd"
+          />
+          <button
+            class="btn btn-outline-secondary"
+            (click)="onsetDp.toggle()"
+            type="button"
+          >
             <i class="fas fa-calendar"></i>
           </button>
         </div>
@@ -37,16 +56,31 @@
       <div class="form-group mb-3">
         <label for="abatementDateTime">Abatement Date</label>
         <div class="input-group">
-          <input class="form-control" id="abatementDateTime" formControlName="abatementDateTime"
-                 ngbDatepicker #abatementDp="ngbDatepicker" placeholder="yyyy-mm-dd"/>
-          <button class="btn btn-outline-secondary" (click)="abatementDp.toggle()" type="button">
+          <input
+            class="form-control"
+            id="abatementDateTime"
+            formControlName="abatementDateTime"
+            ngbDatepicker
+            #abatementDp="ngbDatepicker"
+            placeholder="yyyy-mm-dd"
+          />
+          <button
+            class="btn btn-outline-secondary"
+            (click)="abatementDp.toggle()"
+            type="button"
+          >
             <i class="fas fa-calendar"></i>
           </button>
         </div>
       </div>
       <div class="form-group mb-3">
         <label for="conditionNote">Notes</label>
-        <textarea class="form-control" id="conditionNote" formControlName="note" rows="3"></textarea>
+        <textarea
+          class="form-control"
+          id="conditionNote"
+          formControlName="note"
+          rows="3"
+        ></textarea>
       </div>
     </ng-container>
 
@@ -67,9 +101,19 @@
       <div class="form-group mb-3">
         <label for="effectiveDateTime">Effective Date</label>
         <div class="input-group">
-          <input class="form-control" id="effectiveDateTime" formControlName="effectiveDateTime"
-                 ngbDatepicker #effectiveDp="ngbDatepicker" placeholder="yyyy-mm-dd"/>
-          <button class="btn btn-outline-secondary" (click)="effectiveDp.toggle()" type="button">
+          <input
+            class="form-control"
+            id="effectiveDateTime"
+            formControlName="effectiveDateTime"
+            ngbDatepicker
+            #effectiveDp="ngbDatepicker"
+            placeholder="yyyy-mm-dd"
+          />
+          <button
+            class="btn btn-outline-secondary"
+            (click)="effectiveDp.toggle()"
+            type="button"
+          >
             <i class="fas fa-calendar"></i>
           </button>
         </div>
@@ -78,20 +122,40 @@
         <div class="form-group mb-3">
           <label for="valueQuantityValue">Value</label>
           <div class="input-group">
-            <input type="number" class="form-control" id="valueQuantityValue" formControlName="valueQuantityValue"/>
-            <input type="text" class="form-control" formControlName="valueQuantityUnit" placeholder="unit"/>
+            <input
+              type="number"
+              class="form-control"
+              id="valueQuantityValue"
+              formControlName="valueQuantityValue"
+            />
+            <input
+              type="text"
+              class="form-control"
+              formControlName="valueQuantityUnit"
+              placeholder="unit"
+            />
           </div>
         </div>
       </ng-container>
       <ng-container *ngIf="hasValueString()">
         <div class="form-group mb-3">
           <label for="valueString">Value</label>
-          <input type="text" class="form-control" id="valueString" formControlName="valueString"/>
+          <input
+            type="text"
+            class="form-control"
+            id="valueString"
+            formControlName="valueString"
+          />
         </div>
       </ng-container>
       <div class="form-group mb-3">
         <label for="obsNote">Notes</label>
-        <textarea class="form-control" id="obsNote" formControlName="note" rows="3"></textarea>
+        <textarea
+          class="form-control"
+          id="obsNote"
+          formControlName="note"
+          rows="3"
+        ></textarea>
       </div>
     </ng-container>
 
@@ -125,20 +189,40 @@
       <div class="form-group mb-3">
         <label for="authoredOn">Authored On</label>
         <div class="input-group">
-          <input class="form-control" id="authoredOn" formControlName="authoredOn"
-                 ngbDatepicker #authoredOnDp="ngbDatepicker" placeholder="yyyy-mm-dd"/>
-          <button class="btn btn-outline-secondary" (click)="authoredOnDp.toggle()" type="button">
+          <input
+            class="form-control"
+            id="authoredOn"
+            formControlName="authoredOn"
+            ngbDatepicker
+            #authoredOnDp="ngbDatepicker"
+            placeholder="yyyy-mm-dd"
+          />
+          <button
+            class="btn btn-outline-secondary"
+            (click)="authoredOnDp.toggle()"
+            type="button"
+          >
             <i class="fas fa-calendar"></i>
           </button>
         </div>
       </div>
       <div class="form-group mb-3">
         <label for="dosage">Dosage</label>
-        <input type="text" class="form-control" id="dosage" formControlName="dosage"/>
+        <input
+          type="text"
+          class="form-control"
+          id="dosage"
+          formControlName="dosage"
+        />
       </div>
       <div class="form-group mb-3">
         <label for="medNote">Notes</label>
-        <textarea class="form-control" id="medNote" formControlName="note" rows="3"></textarea>
+        <textarea
+          class="form-control"
+          id="medNote"
+          formControlName="note"
+          rows="3"
+        ></textarea>
       </div>
     </ng-container>
 
@@ -159,9 +243,19 @@
       <div class="form-group mb-3">
         <label for="periodStart">Period Start</label>
         <div class="input-group">
-          <input class="form-control" id="periodStart" formControlName="periodStart"
-                 ngbDatepicker #periodStartDp="ngbDatepicker" placeholder="yyyy-mm-dd"/>
-          <button class="btn btn-outline-secondary" (click)="periodStartDp.toggle()" type="button">
+          <input
+            class="form-control"
+            id="periodStart"
+            formControlName="periodStart"
+            ngbDatepicker
+            #periodStartDp="ngbDatepicker"
+            placeholder="yyyy-mm-dd"
+          />
+          <button
+            class="btn btn-outline-secondary"
+            (click)="periodStartDp.toggle()"
+            type="button"
+          >
             <i class="fas fa-calendar"></i>
           </button>
         </div>
@@ -169,9 +263,19 @@
       <div class="form-group mb-3">
         <label for="periodEnd">Period End</label>
         <div class="input-group">
-          <input class="form-control" id="periodEnd" formControlName="periodEnd"
-                 ngbDatepicker #periodEndDp="ngbDatepicker" placeholder="yyyy-mm-dd"/>
-          <button class="btn btn-outline-secondary" (click)="periodEndDp.toggle()" type="button">
+          <input
+            class="form-control"
+            id="periodEnd"
+            formControlName="periodEnd"
+            ngbDatepicker
+            #periodEndDp="ngbDatepicker"
+            placeholder="yyyy-mm-dd"
+          />
+          <button
+            class="btn btn-outline-secondary"
+            (click)="periodEndDp.toggle()"
+            type="button"
+          >
             <i class="fas fa-calendar"></i>
           </button>
         </div>
@@ -182,7 +286,11 @@
     <ng-container *ngIf="resourceType === 'AllergyIntolerance'">
       <div class="form-group mb-3">
         <label for="allergyStatus">Clinical Status</label>
-        <select class="form-control" id="allergyStatus" formControlName="clinicalStatus">
+        <select
+          class="form-control"
+          id="allergyStatus"
+          formControlName="clinicalStatus"
+        >
           <option value="active">active</option>
           <option value="inactive">inactive</option>
           <option value="resolved">resolved</option>
@@ -200,16 +308,31 @@
       <div class="form-group mb-3">
         <label for="recordedDate">Recorded Date</label>
         <div class="input-group">
-          <input class="form-control" id="recordedDate" formControlName="recordedDate"
-                 ngbDatepicker #recordedDateDp="ngbDatepicker" placeholder="yyyy-mm-dd"/>
-          <button class="btn btn-outline-secondary" (click)="recordedDateDp.toggle()" type="button">
+          <input
+            class="form-control"
+            id="recordedDate"
+            formControlName="recordedDate"
+            ngbDatepicker
+            #recordedDateDp="ngbDatepicker"
+            placeholder="yyyy-mm-dd"
+          />
+          <button
+            class="btn btn-outline-secondary"
+            (click)="recordedDateDp.toggle()"
+            type="button"
+          >
             <i class="fas fa-calendar"></i>
           </button>
         </div>
       </div>
       <div class="form-group mb-3">
         <label for="allergyNote">Notes</label>
-        <textarea class="form-control" id="allergyNote" formControlName="note" rows="3"></textarea>
+        <textarea
+          class="form-control"
+          id="allergyNote"
+          formControlName="note"
+          rows="3"
+        ></textarea>
       </div>
     </ng-container>
 
@@ -230,16 +353,31 @@
       <div class="form-group mb-3">
         <label for="performedDateTime">Performed Date</label>
         <div class="input-group">
-          <input class="form-control" id="performedDateTime" formControlName="performedDateTime"
-                 ngbDatepicker #performedDp="ngbDatepicker" placeholder="yyyy-mm-dd"/>
-          <button class="btn btn-outline-secondary" (click)="performedDp.toggle()" type="button">
+          <input
+            class="form-control"
+            id="performedDateTime"
+            formControlName="performedDateTime"
+            ngbDatepicker
+            #performedDp="ngbDatepicker"
+            placeholder="yyyy-mm-dd"
+          />
+          <button
+            class="btn btn-outline-secondary"
+            (click)="performedDp.toggle()"
+            type="button"
+          >
             <i class="fas fa-calendar"></i>
           </button>
         </div>
       </div>
       <div class="form-group mb-3">
         <label for="procNote">Notes</label>
-        <textarea class="form-control" id="procNote" formControlName="note" rows="3"></textarea>
+        <textarea
+          class="form-control"
+          id="procNote"
+          formControlName="note"
+          rows="3"
+        ></textarea>
       </div>
     </ng-container>
 
@@ -256,22 +394,43 @@
       <div class="form-group mb-3">
         <label for="occurrenceDateTime">Occurrence Date</label>
         <div class="input-group">
-          <input class="form-control" id="occurrenceDateTime" formControlName="occurrenceDateTime"
-                 ngbDatepicker #occurrenceDp="ngbDatepicker" placeholder="yyyy-mm-dd"/>
-          <button class="btn btn-outline-secondary" (click)="occurrenceDp.toggle()" type="button">
+          <input
+            class="form-control"
+            id="occurrenceDateTime"
+            formControlName="occurrenceDateTime"
+            ngbDatepicker
+            #occurrenceDp="ngbDatepicker"
+            placeholder="yyyy-mm-dd"
+          />
+          <button
+            class="btn btn-outline-secondary"
+            (click)="occurrenceDp.toggle()"
+            type="button"
+          >
             <i class="fas fa-calendar"></i>
           </button>
         </div>
       </div>
       <div class="form-group mb-3">
         <label for="immunNote">Notes</label>
-        <textarea class="form-control" id="immunNote" formControlName="note" rows="3"></textarea>
+        <textarea
+          class="form-control"
+          id="immunNote"
+          formControlName="note"
+          rows="3"
+        ></textarea>
       </div>
     </ng-container>
   </div>
 
   <div class="modal-footer">
-    <button type="button" class="btn btn-outline-light" (click)="activeModal.dismiss()">Cancel</button>
+    <button
+      type="button"
+      class="btn btn-outline-light"
+      (click)="activeModal.dismiss()"
+    >
+      Cancel
+    </button>
     <button type="submit" class="btn btn-indigo" [disabled]="saving">
       <span *ngIf="saving" class="spinner-border spinner-border-sm mr-1"></span>
       Save Changes

--- a/frontend/src/app/components/resource-edit/resource-edit.component.spec.ts
+++ b/frontend/src/app/components/resource-edit/resource-edit.component.spec.ts
@@ -1,0 +1,403 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ResourceEditComponent } from './resource-edit.component';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HTTP_CLIENT_TOKEN } from '../../dependency-injection';
+import { HttpClient } from '@angular/common/http';
+import { FastenApiService } from '../../services/fasten-api.service';
+import { ToastService } from '../../services/toast.service';
+import { of, throwError } from 'rxjs';
+
+describe('ResourceEditComponent', () => {
+  let component: ResourceEditComponent;
+  let fixture: ComponentFixture<ResourceEditComponent>;
+  let mockActiveModal: jasmine.SpyObj<NgbActiveModal>;
+  let mockFastenApi: jasmine.SpyObj<FastenApiService>;
+  let mockToastService: jasmine.SpyObj<ToastService>;
+
+  beforeEach(async () => {
+    mockActiveModal = jasmine.createSpyObj('NgbActiveModal', ['close', 'dismiss']);
+    mockFastenApi = jasmine.createSpyObj('FastenApiService', ['updateResourceBySourceId']);
+    mockToastService = jasmine.createSpyObj('ToastService', ['show']);
+
+    await TestBed.configureTestingModule({
+      imports: [ResourceEditComponent, HttpClientTestingModule],
+      providers: [
+        { provide: NgbActiveModal, useValue: mockActiveModal },
+        { provide: FastenApiService, useValue: mockFastenApi },
+        { provide: ToastService, useValue: mockToastService },
+        { provide: HTTP_CLIENT_TOKEN, useClass: HttpClient },
+      ],
+    }).compileComponents();
+  });
+
+  function createComponent(resourceType: string, resourceRaw: any) {
+    fixture = TestBed.createComponent(ResourceEditComponent);
+    component = fixture.componentInstance;
+    component.resourceType = resourceType;
+    component.resourceRaw = JSON.parse(JSON.stringify(resourceRaw));
+    component.sourceId = 'source-123';
+    component.sourceResourceId = 'resource-456';
+    fixture.detectChanges();
+  }
+
+  // ── Creation / form building ──
+
+  it('should create', () => {
+    createComponent('Condition', { clinicalStatus: { coding: [{ code: 'active' }] } });
+    expect(component).toBeTruthy();
+  });
+
+  it('should build Condition form with correct initial values', () => {
+    createComponent('Condition', {
+      clinicalStatus: { coding: [{ code: 'active' }] },
+      onsetDateTime: '2023-06-15',
+      note: [{ text: 'Test note' }],
+    });
+    expect(component.form.get('clinicalStatus').value).toBe('active');
+    expect(component.form.get('onsetDateTime').value).toEqual({ year: 2023, month: 6, day: 15 });
+    expect(component.form.get('note').value).toBe('Test note');
+  });
+
+  it('should build Observation form with valueQuantity fields', () => {
+    createComponent('Observation', {
+      status: 'final',
+      effectiveDateTime: '2024-01-10',
+      valueQuantity: { value: 7.2, unit: '%' },
+    });
+    expect(component.form.get('status').value).toBe('final');
+    expect(component.form.get('valueQuantityValue').value).toBe(7.2);
+    expect(component.form.get('valueQuantityUnit').value).toBe('%');
+  });
+
+  it('should build Observation form with valueString field', () => {
+    createComponent('Observation', {
+      status: 'final',
+      valueString: 'Positive',
+    });
+    expect(component.form.get('valueString').value).toBe('Positive');
+  });
+
+  it('should build MedicationRequest form with correct initial values', () => {
+    createComponent('MedicationRequest', {
+      status: 'active',
+      intent: 'order',
+      authoredOn: '2022-03-10',
+      dosageInstruction: [{ text: 'Take 1 tablet daily' }],
+    });
+    expect(component.form.get('status').value).toBe('active');
+    expect(component.form.get('intent').value).toBe('order');
+    expect(component.form.get('dosage').value).toBe('Take 1 tablet daily');
+  });
+
+  it('should build Encounter form with period dates', () => {
+    createComponent('Encounter', {
+      status: 'finished',
+      period: { start: '2024-06-15T09:00:00Z', end: '2024-06-15T09:45:00Z' },
+    });
+    expect(component.form.get('status').value).toBe('finished');
+    expect(component.form.get('periodStart').value.year).toBe(2024);
+    expect(component.form.get('periodEnd').value).toBeTruthy();
+  });
+
+  it('should build AllergyIntolerance form with correct initial values', () => {
+    createComponent('AllergyIntolerance', {
+      clinicalStatus: { coding: [{ code: 'active' }] },
+      category: ['medication'],
+      recordedDate: '2020-08-01',
+    });
+    expect(component.form.get('clinicalStatus').value).toBe('active');
+    expect(component.form.get('category').value).toBe('medication');
+  });
+
+  it('should build Procedure form with correct initial values', () => {
+    createComponent('Procedure', {
+      status: 'completed',
+      performedDateTime: '2025-09-03',
+    });
+    expect(component.form.get('status').value).toBe('completed');
+    expect(component.form.get('performedDateTime').value).toEqual({ year: 2025, month: 9, day: 3 });
+  });
+
+  it('should build Immunization form with correct initial values', () => {
+    createComponent('Immunization', {
+      status: 'completed',
+      occurrenceDateTime: '2024-10-15',
+    });
+    expect(component.form.get('status').value).toBe('completed');
+    expect(component.form.get('occurrenceDateTime').value).toEqual({ year: 2024, month: 10, day: 15 });
+  });
+
+  it('should build empty form for unknown resource type', () => {
+    createComponent('Patient', {});
+    expect(Object.keys(component.form.controls).length).toBe(0);
+  });
+
+  // ── Display name extraction ──
+
+  it('should extract display name from code.coding', () => {
+    createComponent('Condition', {
+      code: { coding: [{ display: 'Hypertension' }] },
+      clinicalStatus: { coding: [{ code: 'active' }] },
+    });
+    expect(component.getResourceDisplayName()).toBe('Hypertension');
+  });
+
+  it('should extract display name from code.text', () => {
+    createComponent('Condition', {
+      code: { text: 'Type 2 Diabetes' },
+      clinicalStatus: { coding: [{ code: 'active' }] },
+    });
+    expect(component.getResourceDisplayName()).toBe('Type 2 Diabetes');
+  });
+
+  it('should extract display name from medicationCodeableConcept', () => {
+    createComponent('MedicationRequest', {
+      medicationCodeableConcept: { coding: [{ display: 'Lisinopril 10mg' }] },
+      status: 'active',
+      intent: 'order',
+    });
+    expect(component.getResourceDisplayName()).toBe('Lisinopril 10mg');
+  });
+
+  it('should extract display name from vaccineCode', () => {
+    createComponent('Immunization', {
+      vaccineCode: { coding: [{ display: 'Influenza vaccine' }] },
+      status: 'completed',
+    });
+    expect(component.getResourceDisplayName()).toBe('Influenza vaccine');
+  });
+
+  it('should fall back to resourceType when no display name found', () => {
+    createComponent('Procedure', { status: 'completed' });
+    expect(component.getResourceDisplayName()).toBe('Procedure');
+  });
+
+  // ── Date helpers ──
+
+  it('should parse ISO date string to NgbDateStruct', () => {
+    createComponent('Condition', { clinicalStatus: { coding: [{ code: 'active' }] } });
+    expect(component.parseDate('2023-06-15')).toEqual({ year: 2023, month: 6, day: 15 });
+  });
+
+  it('should return null for null/undefined date', () => {
+    createComponent('Condition', { clinicalStatus: { coding: [{ code: 'active' }] } });
+    expect(component.parseDate(null)).toBeNull();
+    expect(component.parseDate(undefined)).toBeNull();
+  });
+
+  it('should return null for invalid date string', () => {
+    createComponent('Condition', { clinicalStatus: { coding: [{ code: 'active' }] } });
+    expect(component.parseDate('not-a-date')).toBeNull();
+  });
+
+  it('should convert NgbDateStruct to ISO date string', () => {
+    createComponent('Condition', { clinicalStatus: { coding: [{ code: 'active' }] } });
+    const result = component.toIsoDate({ year: 2023, month: 6, day: 15 });
+    expect(result).toContain('2023');
+    expect(new Date(result).getFullYear()).toBe(2023);
+  });
+
+  it('should return null when converting null date struct', () => {
+    createComponent('Condition', { clinicalStatus: { coding: [{ code: 'active' }] } });
+    expect(component.toIsoDate(null)).toBeNull();
+  });
+
+  // ── Value type helpers ──
+
+  it('should detect valueQuantity presence', () => {
+    createComponent('Observation', { status: 'final', valueQuantity: { value: 120 } });
+    expect(component.hasValueQuantity()).toBeTrue();
+  });
+
+  it('should detect valueQuantity absence', () => {
+    createComponent('Observation', { status: 'final' });
+    expect(component.hasValueQuantity()).toBeFalse();
+  });
+
+  it('should detect valueString presence', () => {
+    createComponent('Observation', { status: 'final', valueString: 'Positive' });
+    expect(component.hasValueString()).toBeTrue();
+  });
+
+  it('should detect valueString absence', () => {
+    createComponent('Observation', { status: 'final' });
+    expect(component.hasValueString()).toBeFalse();
+  });
+
+  // ── Merge and submit ──
+
+  it('should merge Condition form values into resource_raw', () => {
+    createComponent('Condition', {
+      clinicalStatus: { coding: [{ code: 'active' }] },
+      onsetDateTime: '2023-01-01',
+    });
+    component.form.get('clinicalStatus').setValue('resolved');
+    component.form.get('note').setValue('Now resolved');
+
+    mockFastenApi.updateResourceBySourceId.and.returnValue(of(true));
+    component.onSubmit();
+
+    expect(component.resourceRaw.clinicalStatus.coding[0].code).toBe('resolved');
+    expect(component.resourceRaw.note[0].text).toBe('Now resolved');
+  });
+
+  it('should merge Observation valueQuantity into resource_raw', () => {
+    createComponent('Observation', {
+      status: 'final',
+      valueQuantity: { value: 7.2, unit: '%' },
+    });
+    component.form.get('valueQuantityValue').setValue(6.5);
+    component.form.get('valueQuantityUnit').setValue('mmol/L');
+
+    mockFastenApi.updateResourceBySourceId.and.returnValue(of(true));
+    component.onSubmit();
+
+    expect(component.resourceRaw.valueQuantity.value).toBe(6.5);
+    expect(component.resourceRaw.valueQuantity.unit).toBe('mmol/L');
+  });
+
+  it('should merge MedicationRequest dosage into resource_raw', () => {
+    createComponent('MedicationRequest', {
+      status: 'active',
+      intent: 'order',
+      dosageInstruction: [{ text: 'Take 1 daily' }],
+    });
+    component.form.get('status').setValue('completed');
+    component.form.get('dosage').setValue('Take 2 daily');
+
+    mockFastenApi.updateResourceBySourceId.and.returnValue(of(true));
+    component.onSubmit();
+
+    expect(component.resourceRaw.status).toBe('completed');
+    expect(component.resourceRaw.dosageInstruction[0].text).toBe('Take 2 daily');
+  });
+
+  it('should merge Encounter period into resource_raw', () => {
+    createComponent('Encounter', {
+      status: 'planned',
+      period: { start: '2024-06-15T09:00:00Z' },
+    });
+    component.form.get('status').setValue('finished');
+
+    mockFastenApi.updateResourceBySourceId.and.returnValue(of(true));
+    component.onSubmit();
+
+    expect(component.resourceRaw.status).toBe('finished');
+  });
+
+  it('should merge AllergyIntolerance category into resource_raw', () => {
+    createComponent('AllergyIntolerance', {
+      clinicalStatus: { coding: [{ code: 'active' }] },
+      category: ['medication'],
+    });
+    component.form.get('category').setValue('food');
+
+    mockFastenApi.updateResourceBySourceId.and.returnValue(of(true));
+    component.onSubmit();
+
+    expect(component.resourceRaw.category).toEqual(['food']);
+  });
+
+  it('should merge Procedure status into resource_raw', () => {
+    createComponent('Procedure', { status: 'in-progress' });
+    component.form.get('status').setValue('completed');
+
+    mockFastenApi.updateResourceBySourceId.and.returnValue(of(true));
+    component.onSubmit();
+
+    expect(component.resourceRaw.status).toBe('completed');
+  });
+
+  it('should merge Immunization status into resource_raw', () => {
+    createComponent('Immunization', { status: 'completed' });
+    component.form.get('status').setValue('entered-in-error');
+
+    mockFastenApi.updateResourceBySourceId.and.returnValue(of(true));
+    component.onSubmit();
+
+    expect(component.resourceRaw.status).toBe('entered-in-error');
+  });
+
+  // ── Submit behavior ──
+
+  it('should call updateResourceBySourceId on submit and close modal on success', () => {
+    createComponent('Condition', {
+      clinicalStatus: { coding: [{ code: 'active' }] },
+    });
+    mockFastenApi.updateResourceBySourceId.and.returnValue(of(true));
+
+    component.onSubmit();
+
+    expect(mockFastenApi.updateResourceBySourceId).toHaveBeenCalledWith(
+      'source-123', 'resource-456', component.resourceRaw
+    );
+    expect(mockActiveModal.close).toHaveBeenCalledWith(component.resourceRaw);
+    expect(mockToastService.show).toHaveBeenCalled();
+    expect(component.saving).toBeFalse();
+  });
+
+  it('should show error toast on submit failure', () => {
+    createComponent('Condition', {
+      clinicalStatus: { coding: [{ code: 'active' }] },
+    });
+    mockFastenApi.updateResourceBySourceId.and.returnValue(throwError(() => ({ error: { message: 'fail' } })));
+
+    component.onSubmit();
+
+    expect(mockActiveModal.close).not.toHaveBeenCalled();
+    expect(mockToastService.show).toHaveBeenCalled();
+    expect(component.saving).toBeFalse();
+  });
+
+  it('should not submit when already saving', () => {
+    createComponent('Condition', {
+      clinicalStatus: { coding: [{ code: 'active' }] },
+    });
+    component.saving = true;
+
+    component.onSubmit();
+
+    expect(mockFastenApi.updateResourceBySourceId).not.toHaveBeenCalled();
+  });
+
+  // ── Note merging edge cases ──
+
+  it('should add note to resource that had no notes', () => {
+    createComponent('Condition', {
+      clinicalStatus: { coding: [{ code: 'active' }] },
+    });
+    component.form.get('note').setValue('Brand new note');
+
+    mockFastenApi.updateResourceBySourceId.and.returnValue(of(true));
+    component.onSubmit();
+
+    expect(component.resourceRaw.note).toEqual([{ text: 'Brand new note' }]);
+  });
+
+  it('should update existing note text', () => {
+    createComponent('Condition', {
+      clinicalStatus: { coding: [{ code: 'active' }] },
+      note: [{ text: 'Old note' }],
+    });
+    component.form.get('note').setValue('Updated note');
+
+    mockFastenApi.updateResourceBySourceId.and.returnValue(of(true));
+    component.onSubmit();
+
+    expect(component.resourceRaw.note[0].text).toBe('Updated note');
+  });
+
+  it('should clear note text when set to empty string', () => {
+    createComponent('Condition', {
+      clinicalStatus: { coding: [{ code: 'active' }] },
+      note: [{ text: 'Will be cleared' }],
+    });
+    component.form.get('note').setValue('');
+
+    mockFastenApi.updateResourceBySourceId.and.returnValue(of(true));
+    component.onSubmit();
+
+    expect(component.resourceRaw.note[0].text).toBe('');
+  });
+});

--- a/frontend/src/app/components/resource-edit/resource-edit.component.spec.ts
+++ b/frontend/src/app/components/resource-edit/resource-edit.component.spec.ts
@@ -16,8 +16,13 @@ describe('ResourceEditComponent', () => {
   let mockToastService: jasmine.SpyObj<ToastService>;
 
   beforeEach(async () => {
-    mockActiveModal = jasmine.createSpyObj('NgbActiveModal', ['close', 'dismiss']);
-    mockFastenApi = jasmine.createSpyObj('FastenApiService', ['updateResourceBySourceId']);
+    mockActiveModal = jasmine.createSpyObj('NgbActiveModal', [
+      'close',
+      'dismiss',
+    ]);
+    mockFastenApi = jasmine.createSpyObj('FastenApiService', [
+      'updateResourceBySourceId',
+    ]);
     mockToastService = jasmine.createSpyObj('ToastService', ['show']);
 
     await TestBed.configureTestingModule({
@@ -44,7 +49,9 @@ describe('ResourceEditComponent', () => {
   // ── Creation / form building ──
 
   it('should create', () => {
-    createComponent('Condition', { clinicalStatus: { coding: [{ code: 'active' }] } });
+    createComponent('Condition', {
+      clinicalStatus: { coding: [{ code: 'active' }] },
+    });
     expect(component).toBeTruthy();
   });
 
@@ -55,7 +62,11 @@ describe('ResourceEditComponent', () => {
       note: [{ text: 'Test note' }],
     });
     expect(component.form.get('clinicalStatus').value).toBe('active');
-    expect(component.form.get('onsetDateTime').value).toEqual({ year: 2023, month: 6, day: 15 });
+    expect(component.form.get('onsetDateTime').value).toEqual({
+      year: 2023,
+      month: 6,
+      day: 15,
+    });
     expect(component.form.get('note').value).toBe('Test note');
   });
 
@@ -116,7 +127,11 @@ describe('ResourceEditComponent', () => {
       performedDateTime: '2025-09-03',
     });
     expect(component.form.get('status').value).toBe('completed');
-    expect(component.form.get('performedDateTime').value).toEqual({ year: 2025, month: 9, day: 3 });
+    expect(component.form.get('performedDateTime').value).toEqual({
+      year: 2025,
+      month: 9,
+      day: 3,
+    });
   });
 
   it('should build Immunization form with correct initial values', () => {
@@ -125,7 +140,11 @@ describe('ResourceEditComponent', () => {
       occurrenceDateTime: '2024-10-15',
     });
     expect(component.form.get('status').value).toBe('completed');
-    expect(component.form.get('occurrenceDateTime').value).toEqual({ year: 2024, month: 10, day: 15 });
+    expect(component.form.get('occurrenceDateTime').value).toEqual({
+      year: 2024,
+      month: 10,
+      day: 15,
+    });
   });
 
   it('should build empty form for unknown resource type', () => {
@@ -176,37 +195,54 @@ describe('ResourceEditComponent', () => {
   // ── Date helpers ──
 
   it('should parse ISO date string to NgbDateStruct', () => {
-    createComponent('Condition', { clinicalStatus: { coding: [{ code: 'active' }] } });
-    expect(component.parseDate('2023-06-15')).toEqual({ year: 2023, month: 6, day: 15 });
+    createComponent('Condition', {
+      clinicalStatus: { coding: [{ code: 'active' }] },
+    });
+    expect(component.parseDate('2023-06-15')).toEqual({
+      year: 2023,
+      month: 6,
+      day: 15,
+    });
   });
 
   it('should return null for null/undefined date', () => {
-    createComponent('Condition', { clinicalStatus: { coding: [{ code: 'active' }] } });
+    createComponent('Condition', {
+      clinicalStatus: { coding: [{ code: 'active' }] },
+    });
     expect(component.parseDate(null)).toBeNull();
     expect(component.parseDate(undefined)).toBeNull();
   });
 
   it('should return null for invalid date string', () => {
-    createComponent('Condition', { clinicalStatus: { coding: [{ code: 'active' }] } });
+    createComponent('Condition', {
+      clinicalStatus: { coding: [{ code: 'active' }] },
+    });
     expect(component.parseDate('not-a-date')).toBeNull();
   });
 
   it('should convert NgbDateStruct to ISO date string', () => {
-    createComponent('Condition', { clinicalStatus: { coding: [{ code: 'active' }] } });
+    createComponent('Condition', {
+      clinicalStatus: { coding: [{ code: 'active' }] },
+    });
     const result = component.toIsoDate({ year: 2023, month: 6, day: 15 });
     expect(result).toContain('2023');
     expect(new Date(result).getFullYear()).toBe(2023);
   });
 
   it('should return null when converting null date struct', () => {
-    createComponent('Condition', { clinicalStatus: { coding: [{ code: 'active' }] } });
+    createComponent('Condition', {
+      clinicalStatus: { coding: [{ code: 'active' }] },
+    });
     expect(component.toIsoDate(null)).toBeNull();
   });
 
   // ── Value type helpers ──
 
   it('should detect valueQuantity presence', () => {
-    createComponent('Observation', { status: 'final', valueQuantity: { value: 120 } });
+    createComponent('Observation', {
+      status: 'final',
+      valueQuantity: { value: 120 },
+    });
     expect(component.hasValueQuantity()).toBeTrue();
   });
 
@@ -216,7 +252,10 @@ describe('ResourceEditComponent', () => {
   });
 
   it('should detect valueString presence', () => {
-    createComponent('Observation', { status: 'final', valueString: 'Positive' });
+    createComponent('Observation', {
+      status: 'final',
+      valueString: 'Positive',
+    });
     expect(component.hasValueString()).toBeTrue();
   });
 
@@ -238,7 +277,9 @@ describe('ResourceEditComponent', () => {
     mockFastenApi.updateResourceBySourceId.and.returnValue(of(true));
     component.onSubmit();
 
-    expect(component.resourceRaw.clinicalStatus.coding[0].code).toBe('resolved');
+    expect(component.resourceRaw.clinicalStatus.coding[0].code).toBe(
+      'resolved',
+    );
     expect(component.resourceRaw.note[0].text).toBe('Now resolved');
   });
 
@@ -270,7 +311,9 @@ describe('ResourceEditComponent', () => {
     component.onSubmit();
 
     expect(component.resourceRaw.status).toBe('completed');
-    expect(component.resourceRaw.dosageInstruction[0].text).toBe('Take 2 daily');
+    expect(component.resourceRaw.dosageInstruction[0].text).toBe(
+      'Take 2 daily',
+    );
   });
 
   it('should merge Encounter period into resource_raw', () => {
@@ -330,7 +373,9 @@ describe('ResourceEditComponent', () => {
     component.onSubmit();
 
     expect(mockFastenApi.updateResourceBySourceId).toHaveBeenCalledWith(
-      'source-123', 'resource-456', component.resourceRaw
+      'source-123',
+      'resource-456',
+      component.resourceRaw,
     );
     expect(mockActiveModal.close).toHaveBeenCalledWith(component.resourceRaw);
     expect(mockToastService.show).toHaveBeenCalled();
@@ -341,7 +386,9 @@ describe('ResourceEditComponent', () => {
     createComponent('Condition', {
       clinicalStatus: { coding: [{ code: 'active' }] },
     });
-    mockFastenApi.updateResourceBySourceId.and.returnValue(throwError(() => ({ error: { message: 'fail' } })));
+    mockFastenApi.updateResourceBySourceId.and.returnValue(
+      throwError(() => ({ error: { message: 'fail' } })),
+    );
 
     component.onSubmit();
 

--- a/frontend/src/app/components/resource-edit/resource-edit.component.ts
+++ b/frontend/src/app/components/resource-edit/resource-edit.component.ts
@@ -1,0 +1,293 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {FormControl, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {NgbActiveModal, NgbDatepickerModule, NgbDateStruct} from '@ng-bootstrap/ng-bootstrap';
+import {FastenApiService} from '../../services/fasten-api.service';
+import {ToastService} from '../../services/toast.service';
+import {ToastNotification, ToastType} from '../../models/fasten/toast';
+import {extractErrorFromResponse} from '../../../lib/utils/error_extract';
+
+@Component({
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    FormsModule,
+    NgbDatepickerModule,
+  ],
+  selector: 'app-resource-edit',
+  templateUrl: './resource-edit.component.html',
+  styleUrls: ['./resource-edit.component.scss'],
+})
+export class ResourceEditComponent implements OnInit {
+  @Input() resourceRaw: any;
+  @Input() resourceType: string;
+  @Input() sourceId: string;
+  @Input() sourceResourceId: string;
+
+  form: FormGroup;
+  saving = false;
+
+  constructor(
+    public activeModal: NgbActiveModal,
+    private fastenApi: FastenApiService,
+    private toastService: ToastService,
+  ) {}
+
+  ngOnInit(): void {
+    this.buildForm();
+  }
+
+  getResourceDisplayName(): string {
+    if (this.resourceRaw?.code?.coding?.[0]?.display) {
+      return this.resourceRaw.code.coding[0].display;
+    }
+    if (this.resourceRaw?.code?.text) {
+      return this.resourceRaw.code.text;
+    }
+    if (this.resourceRaw?.medicationCodeableConcept?.coding?.[0]?.display) {
+      return this.resourceRaw.medicationCodeableConcept.coding[0].display;
+    }
+    if (this.resourceRaw?.medicationCodeableConcept?.text) {
+      return this.resourceRaw.medicationCodeableConcept.text;
+    }
+    if (this.resourceRaw?.vaccineCode?.coding?.[0]?.display) {
+      return this.resourceRaw.vaccineCode.coding[0].display;
+    }
+    if (this.resourceRaw?.vaccineCode?.text) {
+      return this.resourceRaw.vaccineCode.text;
+    }
+    return this.resourceType;
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid || this.saving) {
+      return;
+    }
+    this.saving = true;
+    this.mergeFormIntoResource();
+
+    this.fastenApi.updateResourceBySourceId(this.sourceId, this.sourceResourceId, this.resourceRaw).subscribe(
+      () => {
+        const toast = new ToastNotification();
+        toast.type = ToastType.Success;
+        toast.message = 'Resource updated successfully';
+        this.toastService.show(toast);
+        this.saving = false;
+        this.activeModal.close(this.resourceRaw);
+      },
+      (err) => {
+        const toast = new ToastNotification();
+        toast.type = ToastType.Error;
+        toast.message = `Error updating resource: ${extractErrorFromResponse(err)}`;
+        this.toastService.show(toast);
+        this.saving = false;
+      }
+    );
+  }
+
+  private buildForm(): void {
+    switch (this.resourceType) {
+      case 'Condition':
+        this.form = new FormGroup({
+          clinicalStatus: new FormControl(this.resourceRaw?.clinicalStatus?.coding?.[0]?.code || ''),
+          onsetDateTime: new FormControl(this.parseDate(this.resourceRaw?.onsetDateTime)),
+          abatementDateTime: new FormControl(this.parseDate(this.resourceRaw?.abatementDateTime)),
+          note: new FormControl(this.resourceRaw?.note?.[0]?.text || ''),
+        });
+        break;
+
+      case 'Observation':
+        this.form = new FormGroup({
+          status: new FormControl(this.resourceRaw?.status || ''),
+          effectiveDateTime: new FormControl(this.parseDate(this.resourceRaw?.effectiveDateTime)),
+          valueQuantityValue: new FormControl(this.resourceRaw?.valueQuantity?.value ?? ''),
+          valueQuantityUnit: new FormControl(this.resourceRaw?.valueQuantity?.unit || ''),
+          valueString: new FormControl(this.resourceRaw?.valueString || ''),
+          note: new FormControl(this.resourceRaw?.note?.[0]?.text || ''),
+        });
+        break;
+
+      case 'MedicationRequest':
+        this.form = new FormGroup({
+          status: new FormControl(this.resourceRaw?.status || ''),
+          intent: new FormControl(this.resourceRaw?.intent || ''),
+          authoredOn: new FormControl(this.parseDate(this.resourceRaw?.authoredOn)),
+          dosage: new FormControl(this.resourceRaw?.dosageInstruction?.[0]?.text || ''),
+          note: new FormControl(this.resourceRaw?.note?.[0]?.text || ''),
+        });
+        break;
+
+      case 'Encounter':
+        this.form = new FormGroup({
+          status: new FormControl(this.resourceRaw?.status || ''),
+          periodStart: new FormControl(this.parseDate(this.resourceRaw?.period?.start)),
+          periodEnd: new FormControl(this.parseDate(this.resourceRaw?.period?.end)),
+        });
+        break;
+
+      case 'AllergyIntolerance':
+        this.form = new FormGroup({
+          clinicalStatus: new FormControl(this.resourceRaw?.clinicalStatus?.coding?.[0]?.code || ''),
+          category: new FormControl(this.resourceRaw?.category?.[0] || ''),
+          recordedDate: new FormControl(this.parseDate(this.resourceRaw?.recordedDate)),
+          note: new FormControl(this.resourceRaw?.note?.[0]?.text || ''),
+        });
+        break;
+
+      case 'Procedure':
+        this.form = new FormGroup({
+          status: new FormControl(this.resourceRaw?.status || ''),
+          performedDateTime: new FormControl(this.parseDate(this.resourceRaw?.performedDateTime)),
+          note: new FormControl(this.resourceRaw?.note?.[0]?.text || ''),
+        });
+        break;
+
+      case 'Immunization':
+        this.form = new FormGroup({
+          status: new FormControl(this.resourceRaw?.status || ''),
+          occurrenceDateTime: new FormControl(this.parseDate(this.resourceRaw?.occurrenceDateTime)),
+          note: new FormControl(this.resourceRaw?.note?.[0]?.text || ''),
+        });
+        break;
+
+      default:
+        this.form = new FormGroup({});
+    }
+  }
+
+  private mergeFormIntoResource(): void {
+    const v = this.form.value;
+
+    switch (this.resourceType) {
+      case 'Condition':
+        if (v.clinicalStatus) {
+          this.resourceRaw.clinicalStatus = {
+            coding: [{
+              system: 'http://terminology.hl7.org/CodeSystem/condition-clinical',
+              code: v.clinicalStatus,
+            }]
+          };
+        }
+        this.resourceRaw.onsetDateTime = this.toIsoDate(v.onsetDateTime) || this.resourceRaw.onsetDateTime;
+        if (v.abatementDateTime) {
+          this.resourceRaw.abatementDateTime = this.toIsoDate(v.abatementDateTime);
+        }
+        this.mergeNote(v.note);
+        break;
+
+      case 'Observation':
+        if (v.status) {
+          this.resourceRaw.status = v.status;
+        }
+        this.resourceRaw.effectiveDateTime = this.toIsoDate(v.effectiveDateTime) || this.resourceRaw.effectiveDateTime;
+        if (this.resourceRaw.valueQuantity) {
+          if (v.valueQuantityValue !== '' && v.valueQuantityValue !== null) {
+            this.resourceRaw.valueQuantity.value = parseFloat(v.valueQuantityValue);
+          }
+          if (v.valueQuantityUnit) {
+            this.resourceRaw.valueQuantity.unit = v.valueQuantityUnit;
+          }
+        }
+        if (this.resourceRaw.valueString !== undefined) {
+          this.resourceRaw.valueString = v.valueString;
+        }
+        this.mergeNote(v.note);
+        break;
+
+      case 'MedicationRequest':
+        if (v.status) {
+          this.resourceRaw.status = v.status;
+        }
+        if (v.intent) {
+          this.resourceRaw.intent = v.intent;
+        }
+        this.resourceRaw.authoredOn = this.toIsoDate(v.authoredOn) || this.resourceRaw.authoredOn;
+        if (v.dosage) {
+          this.resourceRaw.dosageInstruction = this.resourceRaw.dosageInstruction || [{}];
+          this.resourceRaw.dosageInstruction[0].text = v.dosage;
+        }
+        this.mergeNote(v.note);
+        break;
+
+      case 'Encounter':
+        if (v.status) {
+          this.resourceRaw.status = v.status;
+        }
+        this.resourceRaw.period = this.resourceRaw.period || {};
+        this.resourceRaw.period.start = this.toIsoDate(v.periodStart) || this.resourceRaw.period.start;
+        this.resourceRaw.period.end = this.toIsoDate(v.periodEnd) || this.resourceRaw.period.end;
+        break;
+
+      case 'AllergyIntolerance':
+        if (v.clinicalStatus) {
+          this.resourceRaw.clinicalStatus = {
+            coding: [{
+              system: 'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical',
+              code: v.clinicalStatus,
+            }]
+          };
+        }
+        if (v.category) {
+          this.resourceRaw.category = [v.category];
+        }
+        this.resourceRaw.recordedDate = this.toIsoDate(v.recordedDate) || this.resourceRaw.recordedDate;
+        this.mergeNote(v.note);
+        break;
+
+      case 'Procedure':
+        if (v.status) {
+          this.resourceRaw.status = v.status;
+        }
+        this.resourceRaw.performedDateTime = this.toIsoDate(v.performedDateTime) || this.resourceRaw.performedDateTime;
+        this.mergeNote(v.note);
+        break;
+
+      case 'Immunization':
+        if (v.status) {
+          this.resourceRaw.status = v.status;
+        }
+        this.resourceRaw.occurrenceDateTime = this.toIsoDate(v.occurrenceDateTime) || this.resourceRaw.occurrenceDateTime;
+        this.mergeNote(v.note);
+        break;
+    }
+  }
+
+  private mergeNote(noteText: string): void {
+    if (noteText) {
+      this.resourceRaw.note = this.resourceRaw.note || [];
+      if (this.resourceRaw.note.length > 0) {
+        this.resourceRaw.note[0].text = noteText;
+      } else {
+        this.resourceRaw.note.push({text: noteText});
+      }
+    } else if (this.resourceRaw.note?.length > 0) {
+      this.resourceRaw.note[0].text = '';
+    }
+  }
+
+  parseDate(isoString: string): NgbDateStruct | null {
+    if (!isoString) return null;
+    // Parse date-only strings (YYYY-MM-DD) directly to avoid UTC timezone shift
+    const dateOnlyMatch = isoString.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (dateOnlyMatch) {
+      return {year: parseInt(dateOnlyMatch[1]), month: parseInt(dateOnlyMatch[2]), day: parseInt(dateOnlyMatch[3])};
+    }
+    const d = new Date(isoString);
+    if (isNaN(d.getTime())) return null;
+    return {year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate()};
+  }
+
+  toIsoDate(dateStruct: NgbDateStruct): string | null {
+    if (!dateStruct) return null;
+    return new Date(dateStruct.year, dateStruct.month - 1, dateStruct.day).toISOString();
+  }
+
+  hasValueQuantity(): boolean {
+    return this.resourceRaw?.valueQuantity !== undefined;
+  }
+
+  hasValueString(): boolean {
+    return this.resourceRaw?.valueString !== undefined;
+  }
+}

--- a/frontend/src/app/components/resource-edit/resource-edit.component.ts
+++ b/frontend/src/app/components/resource-edit/resource-edit.component.ts
@@ -1,11 +1,20 @@
-import {Component, Input, OnInit} from '@angular/core';
-import {CommonModule} from '@angular/common';
-import {FormControl, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {NgbActiveModal, NgbDatepickerModule, NgbDateStruct} from '@ng-bootstrap/ng-bootstrap';
-import {FastenApiService} from '../../services/fasten-api.service';
-import {ToastService} from '../../services/toast.service';
-import {ToastNotification, ToastType} from '../../models/fasten/toast';
-import {extractErrorFromResponse} from '../../../lib/utils/error_extract';
+import { Component, Input, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  FormControl,
+  FormGroup,
+  FormsModule,
+  ReactiveFormsModule,
+} from '@angular/forms';
+import {
+  NgbActiveModal,
+  NgbDatepickerModule,
+  NgbDateStruct,
+} from '@ng-bootstrap/ng-bootstrap';
+import { FastenApiService } from '../../services/fasten-api.service';
+import { ToastService } from '../../services/toast.service';
+import { ToastNotification, ToastType } from '../../models/fasten/toast';
+import { extractErrorFromResponse } from '../../../lib/utils/error_extract';
 
 @Component({
   standalone: true,
@@ -67,32 +76,44 @@ export class ResourceEditComponent implements OnInit {
     this.saving = true;
     this.mergeFormIntoResource();
 
-    this.fastenApi.updateResourceBySourceId(this.sourceId, this.sourceResourceId, this.resourceRaw).subscribe(
-      () => {
-        const toast = new ToastNotification();
-        toast.type = ToastType.Success;
-        toast.message = 'Resource updated successfully';
-        this.toastService.show(toast);
-        this.saving = false;
-        this.activeModal.close(this.resourceRaw);
-      },
-      (err) => {
-        const toast = new ToastNotification();
-        toast.type = ToastType.Error;
-        toast.message = `Error updating resource: ${extractErrorFromResponse(err)}`;
-        this.toastService.show(toast);
-        this.saving = false;
-      }
-    );
+    this.fastenApi
+      .updateResourceBySourceId(
+        this.sourceId,
+        this.sourceResourceId,
+        this.resourceRaw,
+      )
+      .subscribe(
+        () => {
+          const toast = new ToastNotification();
+          toast.type = ToastType.Success;
+          toast.message = 'Resource updated successfully';
+          this.toastService.show(toast);
+          this.saving = false;
+          this.activeModal.close(this.resourceRaw);
+        },
+        (err) => {
+          const toast = new ToastNotification();
+          toast.type = ToastType.Error;
+          toast.message = `Error updating resource: ${extractErrorFromResponse(err)}`;
+          this.toastService.show(toast);
+          this.saving = false;
+        },
+      );
   }
 
   private buildForm(): void {
     switch (this.resourceType) {
       case 'Condition':
         this.form = new FormGroup({
-          clinicalStatus: new FormControl(this.resourceRaw?.clinicalStatus?.coding?.[0]?.code || ''),
-          onsetDateTime: new FormControl(this.parseDate(this.resourceRaw?.onsetDateTime)),
-          abatementDateTime: new FormControl(this.parseDate(this.resourceRaw?.abatementDateTime)),
+          clinicalStatus: new FormControl(
+            this.resourceRaw?.clinicalStatus?.coding?.[0]?.code || '',
+          ),
+          onsetDateTime: new FormControl(
+            this.parseDate(this.resourceRaw?.onsetDateTime),
+          ),
+          abatementDateTime: new FormControl(
+            this.parseDate(this.resourceRaw?.abatementDateTime),
+          ),
           note: new FormControl(this.resourceRaw?.note?.[0]?.text || ''),
         });
         break;
@@ -100,9 +121,15 @@ export class ResourceEditComponent implements OnInit {
       case 'Observation':
         this.form = new FormGroup({
           status: new FormControl(this.resourceRaw?.status || ''),
-          effectiveDateTime: new FormControl(this.parseDate(this.resourceRaw?.effectiveDateTime)),
-          valueQuantityValue: new FormControl(this.resourceRaw?.valueQuantity?.value ?? ''),
-          valueQuantityUnit: new FormControl(this.resourceRaw?.valueQuantity?.unit || ''),
+          effectiveDateTime: new FormControl(
+            this.parseDate(this.resourceRaw?.effectiveDateTime),
+          ),
+          valueQuantityValue: new FormControl(
+            this.resourceRaw?.valueQuantity?.value ?? '',
+          ),
+          valueQuantityUnit: new FormControl(
+            this.resourceRaw?.valueQuantity?.unit || '',
+          ),
           valueString: new FormControl(this.resourceRaw?.valueString || ''),
           note: new FormControl(this.resourceRaw?.note?.[0]?.text || ''),
         });
@@ -112,8 +139,12 @@ export class ResourceEditComponent implements OnInit {
         this.form = new FormGroup({
           status: new FormControl(this.resourceRaw?.status || ''),
           intent: new FormControl(this.resourceRaw?.intent || ''),
-          authoredOn: new FormControl(this.parseDate(this.resourceRaw?.authoredOn)),
-          dosage: new FormControl(this.resourceRaw?.dosageInstruction?.[0]?.text || ''),
+          authoredOn: new FormControl(
+            this.parseDate(this.resourceRaw?.authoredOn),
+          ),
+          dosage: new FormControl(
+            this.resourceRaw?.dosageInstruction?.[0]?.text || '',
+          ),
           note: new FormControl(this.resourceRaw?.note?.[0]?.text || ''),
         });
         break;
@@ -121,16 +152,24 @@ export class ResourceEditComponent implements OnInit {
       case 'Encounter':
         this.form = new FormGroup({
           status: new FormControl(this.resourceRaw?.status || ''),
-          periodStart: new FormControl(this.parseDate(this.resourceRaw?.period?.start)),
-          periodEnd: new FormControl(this.parseDate(this.resourceRaw?.period?.end)),
+          periodStart: new FormControl(
+            this.parseDate(this.resourceRaw?.period?.start),
+          ),
+          periodEnd: new FormControl(
+            this.parseDate(this.resourceRaw?.period?.end),
+          ),
         });
         break;
 
       case 'AllergyIntolerance':
         this.form = new FormGroup({
-          clinicalStatus: new FormControl(this.resourceRaw?.clinicalStatus?.coding?.[0]?.code || ''),
+          clinicalStatus: new FormControl(
+            this.resourceRaw?.clinicalStatus?.coding?.[0]?.code || '',
+          ),
           category: new FormControl(this.resourceRaw?.category?.[0] || ''),
-          recordedDate: new FormControl(this.parseDate(this.resourceRaw?.recordedDate)),
+          recordedDate: new FormControl(
+            this.parseDate(this.resourceRaw?.recordedDate),
+          ),
           note: new FormControl(this.resourceRaw?.note?.[0]?.text || ''),
         });
         break;
@@ -138,7 +177,9 @@ export class ResourceEditComponent implements OnInit {
       case 'Procedure':
         this.form = new FormGroup({
           status: new FormControl(this.resourceRaw?.status || ''),
-          performedDateTime: new FormControl(this.parseDate(this.resourceRaw?.performedDateTime)),
+          performedDateTime: new FormControl(
+            this.parseDate(this.resourceRaw?.performedDateTime),
+          ),
           note: new FormControl(this.resourceRaw?.note?.[0]?.text || ''),
         });
         break;
@@ -146,7 +187,9 @@ export class ResourceEditComponent implements OnInit {
       case 'Immunization':
         this.form = new FormGroup({
           status: new FormControl(this.resourceRaw?.status || ''),
-          occurrenceDateTime: new FormControl(this.parseDate(this.resourceRaw?.occurrenceDateTime)),
+          occurrenceDateTime: new FormControl(
+            this.parseDate(this.resourceRaw?.occurrenceDateTime),
+          ),
           note: new FormControl(this.resourceRaw?.note?.[0]?.text || ''),
         });
         break;
@@ -163,15 +206,21 @@ export class ResourceEditComponent implements OnInit {
       case 'Condition':
         if (v.clinicalStatus) {
           this.resourceRaw.clinicalStatus = {
-            coding: [{
-              system: 'http://terminology.hl7.org/CodeSystem/condition-clinical',
-              code: v.clinicalStatus,
-            }]
+            coding: [
+              {
+                system:
+                  'http://terminology.hl7.org/CodeSystem/condition-clinical',
+                code: v.clinicalStatus,
+              },
+            ],
           };
         }
-        this.resourceRaw.onsetDateTime = this.toIsoDate(v.onsetDateTime) || this.resourceRaw.onsetDateTime;
+        this.resourceRaw.onsetDateTime =
+          this.toIsoDate(v.onsetDateTime) || this.resourceRaw.onsetDateTime;
         if (v.abatementDateTime) {
-          this.resourceRaw.abatementDateTime = this.toIsoDate(v.abatementDateTime);
+          this.resourceRaw.abatementDateTime = this.toIsoDate(
+            v.abatementDateTime,
+          );
         }
         this.mergeNote(v.note);
         break;
@@ -180,10 +229,14 @@ export class ResourceEditComponent implements OnInit {
         if (v.status) {
           this.resourceRaw.status = v.status;
         }
-        this.resourceRaw.effectiveDateTime = this.toIsoDate(v.effectiveDateTime) || this.resourceRaw.effectiveDateTime;
+        this.resourceRaw.effectiveDateTime =
+          this.toIsoDate(v.effectiveDateTime) ||
+          this.resourceRaw.effectiveDateTime;
         if (this.resourceRaw.valueQuantity) {
           if (v.valueQuantityValue !== '' && v.valueQuantityValue !== null) {
-            this.resourceRaw.valueQuantity.value = parseFloat(v.valueQuantityValue);
+            this.resourceRaw.valueQuantity.value = parseFloat(
+              v.valueQuantityValue,
+            );
           }
           if (v.valueQuantityUnit) {
             this.resourceRaw.valueQuantity.unit = v.valueQuantityUnit;
@@ -202,9 +255,11 @@ export class ResourceEditComponent implements OnInit {
         if (v.intent) {
           this.resourceRaw.intent = v.intent;
         }
-        this.resourceRaw.authoredOn = this.toIsoDate(v.authoredOn) || this.resourceRaw.authoredOn;
+        this.resourceRaw.authoredOn =
+          this.toIsoDate(v.authoredOn) || this.resourceRaw.authoredOn;
         if (v.dosage) {
-          this.resourceRaw.dosageInstruction = this.resourceRaw.dosageInstruction || [{}];
+          this.resourceRaw.dosageInstruction = this.resourceRaw
+            .dosageInstruction || [{}];
           this.resourceRaw.dosageInstruction[0].text = v.dosage;
         }
         this.mergeNote(v.note);
@@ -215,23 +270,29 @@ export class ResourceEditComponent implements OnInit {
           this.resourceRaw.status = v.status;
         }
         this.resourceRaw.period = this.resourceRaw.period || {};
-        this.resourceRaw.period.start = this.toIsoDate(v.periodStart) || this.resourceRaw.period.start;
-        this.resourceRaw.period.end = this.toIsoDate(v.periodEnd) || this.resourceRaw.period.end;
+        this.resourceRaw.period.start =
+          this.toIsoDate(v.periodStart) || this.resourceRaw.period.start;
+        this.resourceRaw.period.end =
+          this.toIsoDate(v.periodEnd) || this.resourceRaw.period.end;
         break;
 
       case 'AllergyIntolerance':
         if (v.clinicalStatus) {
           this.resourceRaw.clinicalStatus = {
-            coding: [{
-              system: 'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical',
-              code: v.clinicalStatus,
-            }]
+            coding: [
+              {
+                system:
+                  'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical',
+                code: v.clinicalStatus,
+              },
+            ],
           };
         }
         if (v.category) {
           this.resourceRaw.category = [v.category];
         }
-        this.resourceRaw.recordedDate = this.toIsoDate(v.recordedDate) || this.resourceRaw.recordedDate;
+        this.resourceRaw.recordedDate =
+          this.toIsoDate(v.recordedDate) || this.resourceRaw.recordedDate;
         this.mergeNote(v.note);
         break;
 
@@ -239,7 +300,9 @@ export class ResourceEditComponent implements OnInit {
         if (v.status) {
           this.resourceRaw.status = v.status;
         }
-        this.resourceRaw.performedDateTime = this.toIsoDate(v.performedDateTime) || this.resourceRaw.performedDateTime;
+        this.resourceRaw.performedDateTime =
+          this.toIsoDate(v.performedDateTime) ||
+          this.resourceRaw.performedDateTime;
         this.mergeNote(v.note);
         break;
 
@@ -247,7 +310,9 @@ export class ResourceEditComponent implements OnInit {
         if (v.status) {
           this.resourceRaw.status = v.status;
         }
-        this.resourceRaw.occurrenceDateTime = this.toIsoDate(v.occurrenceDateTime) || this.resourceRaw.occurrenceDateTime;
+        this.resourceRaw.occurrenceDateTime =
+          this.toIsoDate(v.occurrenceDateTime) ||
+          this.resourceRaw.occurrenceDateTime;
         this.mergeNote(v.note);
         break;
     }
@@ -259,7 +324,7 @@ export class ResourceEditComponent implements OnInit {
       if (this.resourceRaw.note.length > 0) {
         this.resourceRaw.note[0].text = noteText;
       } else {
-        this.resourceRaw.note.push({text: noteText});
+        this.resourceRaw.note.push({ text: noteText });
       }
     } else if (this.resourceRaw.note?.length > 0) {
       this.resourceRaw.note[0].text = '';
@@ -271,16 +336,24 @@ export class ResourceEditComponent implements OnInit {
     // Parse date-only strings (YYYY-MM-DD) directly to avoid UTC timezone shift
     const dateOnlyMatch = isoString.match(/^(\d{4})-(\d{2})-(\d{2})$/);
     if (dateOnlyMatch) {
-      return {year: parseInt(dateOnlyMatch[1]), month: parseInt(dateOnlyMatch[2]), day: parseInt(dateOnlyMatch[3])};
+      return {
+        year: parseInt(dateOnlyMatch[1]),
+        month: parseInt(dateOnlyMatch[2]),
+        day: parseInt(dateOnlyMatch[3]),
+      };
     }
     const d = new Date(isoString);
     if (isNaN(d.getTime())) return null;
-    return {year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate()};
+    return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate() };
   }
 
   toIsoDate(dateStruct: NgbDateStruct): string | null {
     if (!dateStruct) return null;
-    return new Date(dateStruct.year, dateStruct.month - 1, dateStruct.day).toISOString();
+    return new Date(
+      dateStruct.year,
+      dateStruct.month - 1,
+      dateStruct.day,
+    ).toISOString();
   }
 
   hasValueQuantity(): boolean {

--- a/frontend/src/app/components/shared.module.ts
+++ b/frontend/src/app/components/shared.module.ts
@@ -37,6 +37,7 @@ import {FhirDatatableModule} from './fhir-datatable/fhir-datatable.module';
 import { MedicalRecordWizardAddEncounterComponent } from './medical-record-wizard-add-encounter/medical-record-wizard-add-encounter.component';
 import { MedicalRecordWizardAddLabResultsComponent } from './medical-record-wizard-add-lab-results/medical-record-wizard-add-lab-results.component';
 import { FormRequestHealthSystemComponent } from './form-request-health-system/form-request-health-system.component';
+import { ResourceEditComponent } from './resource-edit/resource-edit.component';
 
 @NgModule({
   imports: [
@@ -71,6 +72,7 @@ import { FormRequestHealthSystemComponent } from './form-request-health-system/f
     MedicalRecordWizardAddAttachmentComponent,
     MedicalRecordWizardAddEncounterComponent,
     MedicalRecordWizardAddLabResultsComponent,
+    ResourceEditComponent,
 
   ],
   declarations: [
@@ -116,6 +118,7 @@ import { FormRequestHealthSystemComponent } from './form-request-health-system/f
       MedicalRecordWizardAddPractitionerComponent,
       MedicalRecordWizardComponent,
       MedicalRecordWizardAddLabResultsComponent,
+      ResourceEditComponent,
       MedicalSourcesCategoryLookupPipe,
       NlmTypeaheadComponent,
     ]

--- a/frontend/src/app/components/shared.module.ts
+++ b/frontend/src/app/components/shared.module.ts
@@ -3,7 +3,7 @@ import { NgModule } from '@angular/core';
 import { NgxDatatableModule } from '@swimlane/ngx-datatable';
 import { RouterModule } from '@angular/router';
 import { UtilitiesSidebarComponent } from './utilities-sidebar/utilities-sidebar.component';
-import {BrowserModule} from '@angular/platform-browser';
+import { BrowserModule } from '@angular/platform-browser';
 import { GlossaryLookupComponent } from './glossary-lookup/glossary-lookup.component';
 import { LoadingSpinnerComponent } from './loading-spinner/loading-spinner.component';
 import { MedicalSourcesCardComponent } from './medical-sources-card/medical-sources-card.component';
@@ -20,20 +20,26 @@ import { ReportMedicalHistoryEditorComponent } from './report-medical-history-ed
 import { ReportMedicalHistoryExplanationOfBenefitComponent } from './report-medical-history-explanation-of-benefit/report-medical-history-explanation-of-benefit.component';
 import { ToastComponent } from './toast/toast.component';
 import { TreeModule } from '@circlon/angular-tree-component';
-import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {GridstackComponent} from './gridstack/gridstack.component';
-import {GridstackItemComponent} from './gridstack/gridstack-item.component';
-import {HighlightModule} from 'ngx-highlightjs';
-import {NgbCollapseModule, NgbModule, NgbDropdownModule, NgbAccordionModule, NgbNavModule} from '@ng-bootstrap/ng-bootstrap';
-import {PipesModule} from '../pipes/pipes.module';
-import {DirectivesModule} from '../directives/directives.module';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { GridstackComponent } from './gridstack/gridstack.component';
+import { GridstackItemComponent } from './gridstack/gridstack-item.component';
+import { HighlightModule } from 'ngx-highlightjs';
+import {
+  NgbCollapseModule,
+  NgbModule,
+  NgbDropdownModule,
+  NgbAccordionModule,
+  NgbNavModule,
+} from '@ng-bootstrap/ng-bootstrap';
+import { PipesModule } from '../pipes/pipes.module';
+import { DirectivesModule } from '../directives/directives.module';
 import { ReportMedicalHistoryTimelinePanelComponent } from './report-medical-history-timeline-panel/report-medical-history-timeline-panel.component';
 import { MedicalRecordWizardComponent } from './medical-record-wizard/medical-record-wizard.component';
 import { MedicalRecordWizardAddPractitionerComponent } from './medical-record-wizard-add-practitioner/medical-record-wizard-add-practitioner.component';
 import { MedicalRecordWizardAddOrganizationComponent } from './medical-record-wizard-add-organization/medical-record-wizard-add-organization.component';
 import { MedicalRecordWizardAddAttachmentComponent } from './medical-record-wizard-add-attachment/medical-record-wizard-add-attachment.component';
-import {FhirCardModule} from './fhir-card/fhir-card.module';
-import {FhirDatatableModule} from './fhir-datatable/fhir-datatable.module';
+import { FhirCardModule } from './fhir-card/fhir-card.module';
+import { FhirDatatableModule } from './fhir-datatable/fhir-datatable.module';
 import { MedicalRecordWizardAddEncounterComponent } from './medical-record-wizard-add-encounter/medical-record-wizard-add-encounter.component';
 import { MedicalRecordWizardAddLabResultsComponent } from './medical-record-wizard-add-lab-results/medical-record-wizard-add-lab-results.component';
 import { FormRequestHealthSystemComponent } from './form-request-health-system/form-request-health-system.component';
@@ -73,7 +79,6 @@ import { ResourceEditComponent } from './resource-edit/resource-edit.component';
     MedicalRecordWizardAddEncounterComponent,
     MedicalRecordWizardAddLabResultsComponent,
     ResourceEditComponent,
-
   ],
   declarations: [
     ComponentsSidebarComponent,
@@ -92,36 +97,35 @@ import { ResourceEditComponent } from './resource-edit/resource-edit.component';
     MedicalSourcesCardComponent,
     FormRequestHealthSystemComponent,
   ],
-    exports: [
-        ComponentsSidebarComponent,
-        MedicalSourcesFilterComponent,
-        NlmTypeaheadComponent,
-        ReportHeaderComponent,
-        ReportLabsObservationComponent,
-        ReportMedicalHistoryConditionComponent,
-        ReportMedicalHistoryEditorComponent,
-        ReportMedicalHistoryExplanationOfBenefitComponent,
-        ToastComponent,
-        UtilitiesSidebarComponent,
-        MedicalSourcesCardComponent,
-        MedicalSourcesConnectedComponent,
-        ReportMedicalHistoryTimelinePanelComponent,
+  exports: [
+    ComponentsSidebarComponent,
+    MedicalSourcesFilterComponent,
+    NlmTypeaheadComponent,
+    ReportHeaderComponent,
+    ReportLabsObservationComponent,
+    ReportMedicalHistoryConditionComponent,
+    ReportMedicalHistoryEditorComponent,
+    ReportMedicalHistoryExplanationOfBenefitComponent,
+    ToastComponent,
+    UtilitiesSidebarComponent,
+    MedicalSourcesCardComponent,
+    MedicalSourcesConnectedComponent,
+    ReportMedicalHistoryTimelinePanelComponent,
 
-      //standalone components
-      GlossaryLookupComponent,
-      GridstackComponent,
-      GridstackItemComponent,
-      LoadingSpinnerComponent,
-      MedicalRecordWizardAddAttachmentComponent,
-      MedicalRecordWizardAddEncounterComponent,
-      MedicalRecordWizardAddOrganizationComponent,
-      MedicalRecordWizardAddPractitionerComponent,
-      MedicalRecordWizardComponent,
-      MedicalRecordWizardAddLabResultsComponent,
-      ResourceEditComponent,
-      MedicalSourcesCategoryLookupPipe,
-      NlmTypeaheadComponent,
-    ]
+    //standalone components
+    GlossaryLookupComponent,
+    GridstackComponent,
+    GridstackItemComponent,
+    LoadingSpinnerComponent,
+    MedicalRecordWizardAddAttachmentComponent,
+    MedicalRecordWizardAddEncounterComponent,
+    MedicalRecordWizardAddOrganizationComponent,
+    MedicalRecordWizardAddPractitionerComponent,
+    MedicalRecordWizardComponent,
+    MedicalRecordWizardAddLabResultsComponent,
+    ResourceEditComponent,
+    MedicalSourcesCategoryLookupPipe,
+    NlmTypeaheadComponent,
+  ],
 })
-
-export class SharedModule { }
+export class SharedModule {}

--- a/frontend/src/app/pages/resource-detail/resource-detail.component.html
+++ b/frontend/src/app/pages/resource-detail/resource-detail.component.html
@@ -9,6 +9,9 @@
       </div>
 
       <div *ngIf="isManualSource && resource" class="d-flex justify-content-end mb-3">
+        <button class="btn btn-outline-indigo btn-sm mr-2"
+                *ngIf="isEditableResourceType()"
+                (click)="editResource()">Edit Resource</button>
         <button class="btn btn-outline-danger btn-sm" (click)="confirmDelete(deleteConfirmationModal)">Delete Resource</button>
       </div>
 

--- a/frontend/src/app/pages/resource-detail/resource-detail.component.html
+++ b/frontend/src/app/pages/resource-detail/resource-detail.component.html
@@ -8,6 +8,10 @@
         <span>{{resource?.source_resource_id}}</span>
       </div>
 
+      <div *ngIf="isManualSource && resource" class="d-flex justify-content-end mb-3">
+        <button class="btn btn-outline-danger btn-sm" (click)="confirmDelete(deleteConfirmationModal)">Delete Resource</button>
+      </div>
+
       <ng-container *ngIf="!loading else isLoadingTemplate">
 
         <fhir-card *ngIf="displayModel else noDisplayModel" [displayModel]="displayModel" [showDetails]="false"></fhir-card>
@@ -34,3 +38,20 @@
     </div><!-- az-content-body -->
   </div>
 </div>
+
+<ng-template #deleteConfirmationModal let-modal>
+  <div class="modal-header">
+    <h4 class="modal-title" id="modal-delete-title">Delete Resource</h4>
+    <button type="button" class="btn close" aria-label="Close" (click)="modal.dismiss('Cross click')">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <div class="modal-body">
+    <p>Are you sure you want to delete this <strong>{{resource?.source_resource_type}}</strong> resource?</p>
+    <p>This action cannot be undone.</p>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-outline-light" (click)="modal.dismiss('Cancel')">Cancel</button>
+    <button type="button" class="btn btn-danger" (click)="modal.close('delete')">Delete</button>
+  </div>
+</ng-template>

--- a/frontend/src/app/pages/resource-detail/resource-detail.component.html
+++ b/frontend/src/app/pages/resource-detail/resource-detail.component.html
@@ -2,29 +2,50 @@
   <div class="container">
     <div class="az-content-body">
       <div class="az-content-breadcrumb">
-        <span class="cursor-pointer" [routerLink]="['/explore', sourceId]">{{sourceName}}</span>
+        <span class="cursor-pointer" [routerLink]="['/explore', sourceId]">{{
+          sourceName
+        }}</span>
         <span>Resource</span>
-        <span>{{resource?.source_resource_type}}</span>
-        <span>{{resource?.source_resource_id}}</span>
+        <span>{{ resource?.source_resource_type }}</span>
+        <span>{{ resource?.source_resource_id }}</span>
       </div>
 
-      <div *ngIf="isManualSource && resource" class="d-flex justify-content-end mb-3">
-        <button class="btn btn-outline-indigo btn-sm mr-2"
-                *ngIf="isEditableResourceType()"
-                (click)="editResource()">Edit Resource</button>
-        <button class="btn btn-outline-danger btn-sm" (click)="confirmDelete(deleteConfirmationModal)">Delete Resource</button>
+      <div
+        *ngIf="isManualSource && resource"
+        class="d-flex justify-content-end mb-3"
+      >
+        <button
+          class="btn btn-outline-indigo btn-sm mr-2"
+          *ngIf="isEditableResourceType()"
+          (click)="editResource()"
+        >
+          Edit Resource
+        </button>
+        <button
+          class="btn btn-outline-danger btn-sm"
+          (click)="confirmDelete(deleteConfirmationModal)"
+        >
+          Delete Resource
+        </button>
       </div>
 
-      <ng-container *ngIf="!loading else isLoadingTemplate">
-
-        <fhir-card *ngIf="displayModel else noDisplayModel" [displayModel]="displayModel" [showDetails]="false"></fhir-card>
+      <ng-container *ngIf="!loading; else isLoadingTemplate">
+        <fhir-card
+          *ngIf="displayModel; else noDisplayModel"
+          [displayModel]="displayModel"
+          [showDetails]="false"
+        ></fhir-card>
 
         <ng-template #noDisplayModel>
-          <p> An error occurred while parsing FHIR resource </p>
+          <p>An error occurred while parsing FHIR resource</p>
         </ng-template>
 
-        <div style="margin-bottom:50px" class="alert alert-warning" role="alert">
-          Enable Debug mode: <input type="checkbox" [(ngModel)]="debugMode"/>
+        <div
+          style="margin-bottom: 50px"
+          class="alert alert-warning"
+          role="alert"
+        >
+          Enable Debug mode: <input type="checkbox" [(ngModel)]="debugMode" />
         </div>
 
         <ng-container *ngIf="resource && debugMode">
@@ -34,27 +55,50 @@
       <ng-template #isLoadingTemplate>
         <div class="row">
           <div class="col-12">
-            <app-loading-spinner [loadingTitle]="'Please wait, loading report...'"></app-loading-spinner>
+            <app-loading-spinner
+              [loadingTitle]="'Please wait, loading report...'"
+            ></app-loading-spinner>
           </div>
         </div>
       </ng-template>
-    </div><!-- az-content-body -->
+    </div>
+    <!-- az-content-body -->
   </div>
 </div>
 
 <ng-template #deleteConfirmationModal let-modal>
   <div class="modal-header">
     <h4 class="modal-title" id="modal-delete-title">Delete Resource</h4>
-    <button type="button" class="btn close" aria-label="Close" (click)="modal.dismiss('Cross click')">
+    <button
+      type="button"
+      class="btn close"
+      aria-label="Close"
+      (click)="modal.dismiss('Cross click')"
+    >
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
   <div class="modal-body">
-    <p>Are you sure you want to delete this <strong>{{resource?.source_resource_type}}</strong> resource?</p>
+    <p>
+      Are you sure you want to delete this
+      <strong>{{ resource?.source_resource_type }}</strong> resource?
+    </p>
     <p>This action cannot be undone.</p>
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-outline-light" (click)="modal.dismiss('Cancel')">Cancel</button>
-    <button type="button" class="btn btn-danger" (click)="modal.close('delete')">Delete</button>
+    <button
+      type="button"
+      class="btn btn-outline-light"
+      (click)="modal.dismiss('Cancel')"
+    >
+      Cancel
+    </button>
+    <button
+      type="button"
+      class="btn btn-danger"
+      (click)="modal.close('delete')"
+    >
+      Delete
+    </button>
   </div>
 </ng-template>

--- a/frontend/src/app/pages/resource-detail/resource-detail.component.spec.ts
+++ b/frontend/src/app/pages/resource-detail/resource-detail.component.spec.ts
@@ -16,19 +16,29 @@ describe('ResourceDetailComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ResourceDetailComponent],
-      imports: [HttpClientTestingModule, RouterTestingModule, LoadingSpinnerComponent],
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        LoadingSpinnerComponent,
+      ],
       providers: [
         {
           provide: ActivatedRoute,
-          useValue: { snapshot: { paramMap: convertToParamMap({ 'resource_id': 'b64.cmVzb3VyY2VfZmhpcjpiNjQuYzI5MWNtTmxPbUZsZEc1aE9qRXlNelExTmpjNE9UQXhNak0wTlRZM01ETT06UGF0aWVudDoxMjM0NTY3ODkwMTIzNDU2NzAz' }) } }
+          useValue: {
+            snapshot: {
+              paramMap: convertToParamMap({
+                resource_id:
+                  'b64.cmVzb3VyY2VfZmhpcjpiNjQuYzI5MWNtTmxPbUZsZEc1aE9qRXlNelExTmpjNE9UQXhNak0wTlRZM01ETT06UGF0aWVudDoxMjM0NTY3ODkwMTIzNDU2NzAz',
+              }),
+            },
+          },
         },
         {
           provide: HTTP_CLIENT_TOKEN,
           useClass: HttpClient,
         },
-      ]
-    })
-      .compileComponents();
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ResourceDetailComponent);
     component = fixture.componentInstance;
@@ -40,17 +50,30 @@ describe('ResourceDetailComponent', () => {
   });
 
   describe('isEditableResourceType', () => {
-    const editableTypes = ['Condition', 'Observation', 'MedicationRequest', 'Encounter', 'AllergyIntolerance', 'Procedure', 'Immunization'];
-    const nonEditableTypes = ['Patient', 'CarePlan', 'DiagnosticReport', 'DocumentReference'];
+    const editableTypes = [
+      'Condition',
+      'Observation',
+      'MedicationRequest',
+      'Encounter',
+      'AllergyIntolerance',
+      'Procedure',
+      'Immunization',
+    ];
+    const nonEditableTypes = [
+      'Patient',
+      'CarePlan',
+      'DiagnosticReport',
+      'DocumentReference',
+    ];
 
-    editableTypes.forEach(type => {
+    editableTypes.forEach((type) => {
       it(`should return true for ${type}`, () => {
         component.resource = { source_resource_type: type } as any;
         expect(component.isEditableResourceType()).toBeTrue();
       });
     });
 
-    nonEditableTypes.forEach(type => {
+    nonEditableTypes.forEach((type) => {
       it(`should return false for ${type}`, () => {
         component.resource = { source_resource_type: type } as any;
         expect(component.isEditableResourceType()).toBeFalse();
@@ -84,10 +107,16 @@ describe('ResourceDetailComponent', () => {
       expect(modalService.open).toHaveBeenCalled();
       expect(mockModalRef.componentInstance['resourceType']).toBe('Condition');
       expect(mockModalRef.componentInstance['sourceId']).toBe('src-1');
-      expect(mockModalRef.componentInstance['sourceResourceId']).toBe('cond-123');
+      expect(mockModalRef.componentInstance['sourceResourceId']).toBe(
+        'cond-123',
+      );
       // Should be a deep clone, not the same reference
-      expect(mockModalRef.componentInstance['resourceRaw']).not.toBe(component.resource.resource_raw);
-      expect(mockModalRef.componentInstance['resourceRaw']).toEqual(component.resource.resource_raw);
+      expect(mockModalRef.componentInstance['resourceRaw']).not.toBe(
+        component.resource.resource_raw,
+      );
+      expect(mockModalRef.componentInstance['resourceRaw']).toEqual(
+        component.resource.resource_raw,
+      );
     });
   });
 });

--- a/frontend/src/app/pages/resource-detail/resource-detail.component.spec.ts
+++ b/frontend/src/app/pages/resource-detail/resource-detail.component.spec.ts
@@ -1,12 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ResourceDetailComponent } from './resource-detail.component';
-import {HttpClientTestingModule} from '@angular/common/http/testing';
-import {RouterTestingModule} from '@angular/router/testing';
-import {ActivatedRoute, convertToParamMap} from '@angular/router';
-import {HTTP_CLIENT_TOKEN} from '../../dependency-injection';
-import {HttpClient} from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { HTTP_CLIENT_TOKEN } from '../../dependency-injection';
+import { HttpClient } from '@angular/common/http';
 import { LoadingSpinnerComponent } from 'src/app/components/loading-spinner/loading-spinner.component';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
 describe('ResourceDetailComponent', () => {
   let component: ResourceDetailComponent;
@@ -14,12 +15,12 @@ describe('ResourceDetailComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ ResourceDetailComponent ],
+      declarations: [ResourceDetailComponent],
       imports: [HttpClientTestingModule, RouterTestingModule, LoadingSpinnerComponent],
       providers: [
         {
           provide: ActivatedRoute,
-          useValue: {snapshot: {paramMap: convertToParamMap( { 'resource_id': 'b64.cmVzb3VyY2VfZmhpcjpiNjQuYzI5MWNtTmxPbUZsZEc1aE9qRXlNelExTmpjNE9UQXhNak0wTlRZM01ETT06UGF0aWVudDoxMjM0NTY3ODkwMTIzNDU2NzAz' } )}}
+          useValue: { snapshot: { paramMap: convertToParamMap({ 'resource_id': 'b64.cmVzb3VyY2VfZmhpcjpiNjQuYzI5MWNtTmxPbUZsZEc1aE9qRXlNelExTmpjNE9UQXhNak0wTlRZM01ETT06UGF0aWVudDoxMjM0NTY3ODkwMTIzNDU2NzAz' }) } }
         },
         {
           provide: HTTP_CLIENT_TOKEN,
@@ -27,7 +28,7 @@ describe('ResourceDetailComponent', () => {
         },
       ]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(ResourceDetailComponent);
     component = fixture.componentInstance;
@@ -36,5 +37,57 @@ describe('ResourceDetailComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('isEditableResourceType', () => {
+    const editableTypes = ['Condition', 'Observation', 'MedicationRequest', 'Encounter', 'AllergyIntolerance', 'Procedure', 'Immunization'];
+    const nonEditableTypes = ['Patient', 'CarePlan', 'DiagnosticReport', 'DocumentReference'];
+
+    editableTypes.forEach(type => {
+      it(`should return true for ${type}`, () => {
+        component.resource = { source_resource_type: type } as any;
+        expect(component.isEditableResourceType()).toBeTrue();
+      });
+    });
+
+    nonEditableTypes.forEach(type => {
+      it(`should return false for ${type}`, () => {
+        component.resource = { source_resource_type: type } as any;
+        expect(component.isEditableResourceType()).toBeFalse();
+      });
+    });
+
+    it('should return false when resource is null', () => {
+      component.resource = null;
+      expect(component.isEditableResourceType()).toBeFalse();
+    });
+  });
+
+  describe('editResource', () => {
+    it('should open ResourceEditComponent modal', () => {
+      const modalService = TestBed.inject(NgbModal);
+      const mockModalRef = {
+        componentInstance: {},
+        result: new Promise(() => {}),
+      };
+      spyOn(modalService, 'open').and.returnValue(mockModalRef as any);
+
+      component.resource = {
+        source_resource_type: 'Condition',
+        source_resource_id: 'cond-123',
+        resource_raw: { clinicalStatus: { coding: [{ code: 'active' }] } },
+      } as any;
+      component.sourceId = 'src-1';
+
+      component.editResource();
+
+      expect(modalService.open).toHaveBeenCalled();
+      expect(mockModalRef.componentInstance['resourceType']).toBe('Condition');
+      expect(mockModalRef.componentInstance['sourceId']).toBe('src-1');
+      expect(mockModalRef.componentInstance['sourceResourceId']).toBe('cond-123');
+      // Should be a deep clone, not the same reference
+      expect(mockModalRef.componentInstance['resourceRaw']).not.toBe(component.resource.resource_raw);
+      expect(mockModalRef.componentInstance['resourceRaw']).toEqual(component.resource.resource_raw);
+    });
   });
 });

--- a/frontend/src/app/pages/resource-detail/resource-detail.component.ts
+++ b/frontend/src/app/pages/resource-detail/resource-detail.component.ts
@@ -1,34 +1,42 @@
-import {Component, OnInit, ViewChild, TemplateRef} from '@angular/core';
-import {FastenApiService} from '../../services/fasten-api.service';
-import {ActivatedRoute, Router} from '@angular/router';
-import {ResourceFhir} from '../../models/fasten/resource_fhir';
-import {fhirModelFactory} from '../../../lib/models/factory';
-import {ResourceType} from '../../../lib/models/constants';
-import {FastenDisplayModel} from '../../../lib/models/fasten/fasten-display-model';
-import {Source} from '../../models/fasten/source';
-import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
-import {ToastService} from '../../services/toast.service';
-import {ToastNotification, ToastType} from '../../models/fasten/toast';
-import {extractErrorFromResponse} from '../../../lib/utils/error_extract';
-import {ResourceEditComponent} from '../../components/resource-edit/resource-edit.component';
+import { Component, OnInit, ViewChild, TemplateRef } from '@angular/core';
+import { FastenApiService } from '../../services/fasten-api.service';
+import { ActivatedRoute, Router } from '@angular/router';
+import { ResourceFhir } from '../../models/fasten/resource_fhir';
+import { fhirModelFactory } from '../../../lib/models/factory';
+import { ResourceType } from '../../../lib/models/constants';
+import { FastenDisplayModel } from '../../../lib/models/fasten/fasten-display-model';
+import { Source } from '../../models/fasten/source';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { ToastService } from '../../services/toast.service';
+import { ToastNotification, ToastType } from '../../models/fasten/toast';
+import { extractErrorFromResponse } from '../../../lib/utils/error_extract';
+import { ResourceEditComponent } from '../../components/resource-edit/resource-edit.component';
 
-const EDITABLE_TYPES = ['Condition', 'Observation', 'MedicationRequest', 'Encounter', 'AllergyIntolerance', 'Procedure', 'Immunization'];
+const EDITABLE_TYPES = [
+  'Condition',
+  'Observation',
+  'MedicationRequest',
+  'Encounter',
+  'AllergyIntolerance',
+  'Procedure',
+  'Immunization',
+];
 
 @Component({
   selector: 'app-resource-detail',
   templateUrl: './resource-detail.component.html',
-  styleUrls: ['./resource-detail.component.scss']
+  styleUrls: ['./resource-detail.component.scss'],
 })
 export class ResourceDetailComponent implements OnInit {
-  loading: boolean = false
+  loading: boolean = false;
   debugMode = false;
 
-  sourceId: string = ""
-  sourceName: string = ""
-  resource: ResourceFhir = null
-  displayModel: FastenDisplayModel = null
-  source: Source = null
-  isManualSource: boolean = false
+  sourceId: string = '';
+  sourceName: string = '';
+  resource: ResourceFhir = null;
+  displayModel: FastenDisplayModel = null;
+  source: Source = null;
+  isManualSource: boolean = false;
 
   constructor(
     private fastenApi: FastenApiService,
@@ -36,58 +44,78 @@ export class ResourceDetailComponent implements OnInit {
     private route: ActivatedRoute,
     private modalService: NgbModal,
     private toastService: ToastService,
-  ) {
-  }
+  ) {}
 
   ngOnInit(): void {
-    this.loading = true
-    this.sourceId = this.route.snapshot.paramMap.get('source_id')
+    this.loading = true;
+    this.sourceId = this.route.snapshot.paramMap.get('source_id');
 
     this.fastenApi.getSource(this.sourceId).subscribe((source) => {
-      this.source = source
-      this.isManualSource = (source.platform_type === 'manual' || source.platform_type === 'fasten')
-    })
-
-    this.fastenApi.getResourceBySourceId(this.sourceId, this.route.snapshot.paramMap.get('resource_id')).subscribe((resourceFhir) => {
-      this.loading = false
-      this.resource = resourceFhir;
-      this.sourceName = "unknown" //TODO popualte this
-
-      try{
-        let parsed = fhirModelFactory(resourceFhir.source_resource_type as ResourceType, resourceFhir)
-        this.displayModel = parsed
-      } catch (e) {
-        console.error(e)
-      }
-    }, error => {
-      this.loading = false
+      this.source = source;
+      this.isManualSource =
+        source.platform_type === 'manual' || source.platform_type === 'fasten';
     });
+
+    this.fastenApi
+      .getResourceBySourceId(
+        this.sourceId,
+        this.route.snapshot.paramMap.get('resource_id'),
+      )
+      .subscribe(
+        (resourceFhir) => {
+          this.loading = false;
+          this.resource = resourceFhir;
+          this.sourceName = 'unknown'; //TODO popualte this
+
+          try {
+            let parsed = fhirModelFactory(
+              resourceFhir.source_resource_type as ResourceType,
+              resourceFhir,
+            );
+            this.displayModel = parsed;
+          } catch (e) {
+            console.error(e);
+          }
+        },
+        (error) => {
+          this.loading = false;
+        },
+      );
   }
 
   confirmDelete(modal: any) {
-    this.modalService.open(modal, {ariaLabelledBy: 'modal-delete-title'}).result.then(
-      (result) => {
-        if (result === 'delete') {
-          this.fastenApi.deleteResourceBySourceId(this.sourceId, this.resource.source_resource_id).subscribe(
-            (rowsAffected) => {
-              const toastNotification = new ToastNotification()
-              toastNotification.type = ToastType.Success
-              toastNotification.message = `Successfully deleted resource`
-              this.toastService.show(toastNotification)
-              this.router.navigate(['/explore', this.sourceId])
-            },
-            (err) => {
-              const toastNotification = new ToastNotification()
-              toastNotification.type = ToastType.Error
-              toastNotification.message = `An error occurred while deleting resource: ${extractErrorFromResponse(err)}`
-              this.toastService.show(toastNotification)
-              console.error(err)
-            }
-          )
-        }
-      },
-      () => { /* modal dismissed */ }
-    )
+    this.modalService
+      .open(modal, { ariaLabelledBy: 'modal-delete-title' })
+      .result.then(
+        (result) => {
+          if (result === 'delete') {
+            this.fastenApi
+              .deleteResourceBySourceId(
+                this.sourceId,
+                this.resource.source_resource_id,
+              )
+              .subscribe(
+                (rowsAffected) => {
+                  const toastNotification = new ToastNotification();
+                  toastNotification.type = ToastType.Success;
+                  toastNotification.message = `Successfully deleted resource`;
+                  this.toastService.show(toastNotification);
+                  this.router.navigate(['/explore', this.sourceId]);
+                },
+                (err) => {
+                  const toastNotification = new ToastNotification();
+                  toastNotification.type = ToastType.Error;
+                  toastNotification.message = `An error occurred while deleting resource: ${extractErrorFromResponse(err)}`;
+                  this.toastService.show(toastNotification);
+                  console.error(err);
+                },
+              );
+          }
+        },
+        () => {
+          /* modal dismissed */
+        },
+      );
   }
 
   isEditableResourceType(): boolean {
@@ -99,21 +127,30 @@ export class ResourceDetailComponent implements OnInit {
       ariaLabelledBy: 'modal-edit-title',
       size: 'lg',
     });
-    modalRef.componentInstance.resourceRaw = JSON.parse(JSON.stringify(this.resource.resource_raw));
-    modalRef.componentInstance.resourceType = this.resource.source_resource_type;
+    modalRef.componentInstance.resourceRaw = JSON.parse(
+      JSON.stringify(this.resource.resource_raw),
+    );
+    modalRef.componentInstance.resourceType =
+      this.resource.source_resource_type;
     modalRef.componentInstance.sourceId = this.sourceId;
-    modalRef.componentInstance.sourceResourceId = this.resource.source_resource_id;
+    modalRef.componentInstance.sourceResourceId =
+      this.resource.source_resource_id;
 
     modalRef.result.then(
       (updatedRaw) => {
         this.resource.resource_raw = updatedRaw;
         try {
-          this.displayModel = fhirModelFactory(this.resource.source_resource_type as ResourceType, this.resource);
+          this.displayModel = fhirModelFactory(
+            this.resource.source_resource_type as ResourceType,
+            this.resource,
+          );
         } catch (e) {
           console.error(e);
         }
       },
-      () => { /* modal dismissed */ }
+      () => {
+        /* modal dismissed */
+      },
     );
   }
 }

--- a/frontend/src/app/pages/resource-detail/resource-detail.component.ts
+++ b/frontend/src/app/pages/resource-detail/resource-detail.component.ts
@@ -10,6 +10,9 @@ import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {ToastService} from '../../services/toast.service';
 import {ToastNotification, ToastType} from '../../models/fasten/toast';
 import {extractErrorFromResponse} from '../../../lib/utils/error_extract';
+import {ResourceEditComponent} from '../../components/resource-edit/resource-edit.component';
+
+const EDITABLE_TYPES = ['Condition', 'Observation', 'MedicationRequest', 'Encounter', 'AllergyIntolerance', 'Procedure', 'Immunization'];
 
 @Component({
   selector: 'app-resource-detail',
@@ -85,5 +88,32 @@ export class ResourceDetailComponent implements OnInit {
       },
       () => { /* modal dismissed */ }
     )
+  }
+
+  isEditableResourceType(): boolean {
+    return EDITABLE_TYPES.includes(this.resource?.source_resource_type);
+  }
+
+  editResource(): void {
+    const modalRef = this.modalService.open(ResourceEditComponent, {
+      ariaLabelledBy: 'modal-edit-title',
+      size: 'lg',
+    });
+    modalRef.componentInstance.resourceRaw = JSON.parse(JSON.stringify(this.resource.resource_raw));
+    modalRef.componentInstance.resourceType = this.resource.source_resource_type;
+    modalRef.componentInstance.sourceId = this.sourceId;
+    modalRef.componentInstance.sourceResourceId = this.resource.source_resource_id;
+
+    modalRef.result.then(
+      (updatedRaw) => {
+        this.resource.resource_raw = updatedRaw;
+        try {
+          this.displayModel = fhirModelFactory(this.resource.source_resource_type as ResourceType, this.resource);
+        } catch (e) {
+          console.error(e);
+        }
+      },
+      () => { /* modal dismissed */ }
+    );
   }
 }

--- a/frontend/src/app/pages/resource-detail/resource-detail.component.ts
+++ b/frontend/src/app/pages/resource-detail/resource-detail.component.ts
@@ -1,10 +1,15 @@
-import { Component, OnInit } from '@angular/core';
+import {Component, OnInit, ViewChild, TemplateRef} from '@angular/core';
 import {FastenApiService} from '../../services/fasten-api.service';
 import {ActivatedRoute, Router} from '@angular/router';
 import {ResourceFhir} from '../../models/fasten/resource_fhir';
 import {fhirModelFactory} from '../../../lib/models/factory';
 import {ResourceType} from '../../../lib/models/constants';
 import {FastenDisplayModel} from '../../../lib/models/fasten/fasten-display-model';
+import {Source} from '../../models/fasten/source';
+import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
+import {ToastService} from '../../services/toast.service';
+import {ToastNotification, ToastType} from '../../models/fasten/toast';
+import {extractErrorFromResponse} from '../../../lib/utils/error_extract';
 
 @Component({
   selector: 'app-resource-detail',
@@ -15,21 +20,34 @@ export class ResourceDetailComponent implements OnInit {
   loading: boolean = false
   debugMode = false;
 
-
   sourceId: string = ""
   sourceName: string = ""
   resource: ResourceFhir = null
   displayModel: FastenDisplayModel = null
+  source: Source = null
+  isManualSource: boolean = false
 
-  constructor(private fastenApi: FastenApiService, private router: Router, private route: ActivatedRoute) {
+  constructor(
+    private fastenApi: FastenApiService,
+    private router: Router,
+    private route: ActivatedRoute,
+    private modalService: NgbModal,
+    private toastService: ToastService,
+  ) {
   }
 
   ngOnInit(): void {
     this.loading = true
-    this.fastenApi.getResourceBySourceId(this.route.snapshot.paramMap.get('source_id'), this.route.snapshot.paramMap.get('resource_id')).subscribe((resourceFhir) => {
+    this.sourceId = this.route.snapshot.paramMap.get('source_id')
+
+    this.fastenApi.getSource(this.sourceId).subscribe((source) => {
+      this.source = source
+      this.isManualSource = (source.platform_type === 'manual' || source.platform_type === 'fasten')
+    })
+
+    this.fastenApi.getResourceBySourceId(this.sourceId, this.route.snapshot.paramMap.get('resource_id')).subscribe((resourceFhir) => {
       this.loading = false
       this.resource = resourceFhir;
-      this.sourceId = this.route.snapshot.paramMap.get('source_id')
       this.sourceName = "unknown" //TODO popualte this
 
       try{
@@ -43,4 +61,29 @@ export class ResourceDetailComponent implements OnInit {
     });
   }
 
+  confirmDelete(modal: any) {
+    this.modalService.open(modal, {ariaLabelledBy: 'modal-delete-title'}).result.then(
+      (result) => {
+        if (result === 'delete') {
+          this.fastenApi.deleteResourceBySourceId(this.sourceId, this.resource.source_resource_id).subscribe(
+            (rowsAffected) => {
+              const toastNotification = new ToastNotification()
+              toastNotification.type = ToastType.Success
+              toastNotification.message = `Successfully deleted resource`
+              this.toastService.show(toastNotification)
+              this.router.navigate(['/explore', this.sourceId])
+            },
+            (err) => {
+              const toastNotification = new ToastNotification()
+              toastNotification.type = ToastType.Error
+              toastNotification.message = `An error occurred while deleting resource: ${extractErrorFromResponse(err)}`
+              this.toastService.show(toastNotification)
+              console.error(err)
+            }
+          )
+        }
+      },
+      () => { /* modal dismissed */ }
+    )
+  }
 }

--- a/frontend/src/app/services/fasten-api.service.ts
+++ b/frontend/src/app/services/fasten-api.service.ts
@@ -1,97 +1,114 @@
-import {Inject, Injectable} from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import { Practitioner } from 'src/app/models/fasten/practitioner';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import {Observable, of} from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { Router } from '@angular/router';
-import {map} from 'rxjs/operators';
-import {ResponseWrapper} from '../models/response-wrapper';
-import {Source} from '../models/fasten/source';
-import {User} from '../models/fasten/user';
-import {ResourceFhir} from '../models/fasten/resource_fhir';
-import {SourceSummary} from '../models/fasten/source-summary';
-import {Summary} from '../models/fasten/summary';
-import {AuthService} from './auth.service';
-import {GetEndpointAbsolutePath} from '../../lib/utils/endpoint_absolute_path';
-import {environment} from '../../environments/environment';
-import {ValueSet} from 'fhir/r4';
-import {AttachmentModel} from '../../lib/models/datatypes/attachment-model';
-import {BinaryModel} from '../../lib/models/resources/binary-model';
-import {HTTP_CLIENT_TOKEN} from "../dependency-injection";
+import { map } from 'rxjs/operators';
+import { ResponseWrapper } from '../models/response-wrapper';
+import { Source } from '../models/fasten/source';
+import { User } from '../models/fasten/user';
+import { ResourceFhir } from '../models/fasten/resource_fhir';
+import { SourceSummary } from '../models/fasten/source-summary';
+import { Summary } from '../models/fasten/summary';
+import { AuthService } from './auth.service';
+import { GetEndpointAbsolutePath } from '../../lib/utils/endpoint_absolute_path';
+import { environment } from '../../environments/environment';
+import { ValueSet } from 'fhir/r4';
+import { AttachmentModel } from '../../lib/models/datatypes/attachment-model';
+import { BinaryModel } from '../../lib/models/resources/binary-model';
+import { HTTP_CLIENT_TOKEN } from '../dependency-injection';
 import * as fhirpath from 'fhirpath';
 import _ from 'lodash';
-import {DashboardConfig} from '../models/widget/dashboard-config';
-import {DashboardWidgetQuery} from '../models/widget/dashboard-widget-query';
-import {ResourceGraphResponse} from '../models/fasten/resource-graph-response';
+import { DashboardConfig } from '../models/widget/dashboard-config';
+import { DashboardWidgetQuery } from '../models/widget/dashboard-widget-query';
+import { ResourceGraphResponse } from '../models/fasten/resource-graph-response';
 import { fetchEventSource } from '@microsoft/fetch-event-source';
-import {BackgroundJob, BackgroundJobSyncData} from '../models/fasten/background-job';
-import {SupportRequest} from '../models/fasten/support-request';
 import {
-  List
-} from 'fhir/r4';
-import {FormRequestHealthSystem} from '../models/fasten/form-request-health-system';
+  BackgroundJob,
+  BackgroundJobSyncData,
+} from '../models/fasten/background-job';
+import { SupportRequest } from '../models/fasten/support-request';
+import { List } from 'fhir/r4';
+import { FormRequestHealthSystem } from '../models/fasten/form-request-health-system';
 import { UpdateResourcePayload } from '../models/fasten/resource_update';
 import { Favorite } from '../pages/practitioner-list/practitioner-list.component';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class FastenApiService {
+  private _eventBus: Observable<Event>;
+  private _eventBusAbortController: AbortController;
 
-  private _eventBus: Observable<Event>
-  private _eventBusAbortController: AbortController
-
-  constructor(@Inject(HTTP_CLIENT_TOKEN) private _httpClient: HttpClient,  private router: Router, private authService: AuthService) {
-  }
+  constructor(
+    @Inject(HTTP_CLIENT_TOKEN) private _httpClient: HttpClient,
+    private router: Router,
+    private authService: AuthService,
+  ) {}
 
   /*
   TERMINOLOGY SERVER/GLOSSARY ENDPOINTS
   */
-  getGlossarySearchByCode(code: string, codeSystem: string): Observable<ValueSet> {
-
-    const endpointUrl = new URL(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/glossary/code`);
+  getGlossarySearchByCode(
+    code: string,
+    codeSystem: string,
+  ): Observable<ValueSet> {
+    const endpointUrl = new URL(
+      `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/glossary/code`,
+    );
     endpointUrl.searchParams.set('code', code);
     endpointUrl.searchParams.set('code_system', codeSystem);
 
-    return this._httpClient.get<any>(endpointUrl.toString())
-      .pipe(
-        map((response: ValueSet) => {
-          return response
-        })
-      );
+    return this._httpClient.get<any>(endpointUrl.toString()).pipe(
+      map((response: ValueSet) => {
+        return response;
+      }),
+    );
   }
 
   getHealth(): Observable<any> {
-    return this._httpClient.get<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/health`)
+    return this._httpClient
+      .get<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/health`,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data
-        })
+          return response.data;
+        }),
       );
   }
 
   getEncryptionKey(): Observable<string> {
-    return this._httpClient.get<{ data: string }>(
-      `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/encryption-key`
-    ).pipe(
-      map(response => response?.data)
-    );
+    return this._httpClient
+      .get<{
+        data: string;
+      }>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/encryption-key`)
+      .pipe(map((response) => response?.data));
   }
 
   setupEncryptionKey(encryptionKey: string): Observable<any> {
-    return this._httpClient.post<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/encryption-key`, { encryption_key: encryptionKey })
+    return this._httpClient
+      .post<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/encryption-key`,
+        { encryption_key: encryptionKey },
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data
-        })
+          return response.data;
+        }),
       );
   }
 
   validateEncryptionKey(encryptionKey: string): Observable<any> {
-    return this._httpClient.post<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/encryption-key/validate`, { encryption_key: encryptionKey })
+    return this._httpClient
+      .post<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/encryption-key/validate`,
+        { encryption_key: encryptionKey },
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data
-        })
+          return response.data;
+        }),
       );
   }
 
@@ -100,154 +117,208 @@ export class FastenApiService {
   */
 
   deleteAccount(): Observable<boolean> {
-    return this._httpClient.delete<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/account/me`)
+    return this._httpClient
+      .delete<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/account/me`,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          if(response.success) {
+          if (response.success) {
             this.authService.Logout().then(() => {
-              this.router.navigateByUrl('/auth/signup')
-            })
+              this.router.navigateByUrl('/auth/signup');
+            });
           }
-          return response.success
-        })
+          return response.success;
+        }),
       );
   }
 
   //TODO: Any significant API changes here should also be reflected in EventBusService
 
   getDashboards(): Observable<DashboardConfig[]> {
-    return this._httpClient.get<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/dashboards`, )
+    return this._httpClient
+      .get<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/dashboards`,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data as DashboardConfig[]
-        })
+          return response.data as DashboardConfig[];
+        }),
       );
   }
 
   getSummary(): Observable<Summary> {
-    return this._httpClient.get<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/summary`, )
+    return this._httpClient
+      .get<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/summary`,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data as Summary
-        })
+          return response.data as Summary;
+        }),
       );
   }
 
   createSource(source: Source): Observable<any> {
-    return this._httpClient.post<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/source`, source)
+    return this._httpClient
+      .post<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/source`,
+        source,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
           // @ts-ignore
-          return {summary: response.data, source: response.source}
-        })
+          return { summary: response.data, source: response.source };
+        }),
       );
   }
 
   createManualSource(file: File): Observable<Source> {
-
     const formData = new FormData();
     formData.append('file', file);
 
-    return this._httpClient.post<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/source/manual`, formData)
+    return this._httpClient
+      .post<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/source/manual`,
+        formData,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data as Source
-        })
+          return response.data as Source;
+        }),
       );
   }
 
   createRelatedResourcesFastenSource(resourceList: List): Observable<Source> {
-
-    let bundleBlob = new Blob([JSON.stringify(resourceList)], { type: 'application/json' });
-    let bundleFile = new File([ bundleBlob ], 'related.json', { type: 'application/json' });
+    let bundleBlob = new Blob([JSON.stringify(resourceList)], {
+      type: 'application/json',
+    });
+    let bundleFile = new File([bundleBlob], 'related.json', {
+      type: 'application/json',
+    });
 
     const formData = new FormData();
     formData.append('file', bundleFile);
 
-    return this._httpClient.post<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/related`, formData)
+    return this._httpClient
+      .post<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/related`,
+        formData,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data as Source
-        })
+          return response.data as Source;
+        }),
       );
   }
 
-  removeEncounterRelatedResource(encounterId: string, resourceId: string, resourceType: string) : Observable<any> {
-    return this._httpClient.delete<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/encounter/${encounterId}/related/${resourceType}/${resourceId}`)
+  removeEncounterRelatedResource(
+    encounterId: string,
+    resourceId: string,
+    resourceType: string,
+  ): Observable<any> {
+    return this._httpClient
+      .delete<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/encounter/${encounterId}/related/${resourceType}/${resourceId}`,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data
-        })
+          return response.data;
+        }),
       );
   }
-
 
   getSources(): Observable<Source[]> {
-    return this._httpClient.get<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/source`)
+    return this._httpClient
+      .get<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/source`,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data as Source[]
-        })
+          return response.data as Source[];
+        }),
       );
   }
 
   getSource(sourceId: string): Observable<Source> {
-    return this._httpClient.get<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/source/${sourceId}`)
+    return this._httpClient
+      .get<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/source/${sourceId}`,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data as Source
-        })
+          return response.data as Source;
+        }),
       );
   }
 
   getSourceSummary(sourceId: string): Observable<SourceSummary> {
-    return this._httpClient.get<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/source/${sourceId}/summary`)
+    return this._httpClient
+      .get<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/source/${sourceId}/summary`,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data as SourceSummary
-        })
+          return response.data as SourceSummary;
+        }),
       );
   }
 
   deleteSource(sourceId: string): Observable<number> {
-    return this._httpClient.delete<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/source/${sourceId}`)
+    return this._httpClient
+      .delete<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/source/${sourceId}`,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data as number
-        })
+          return response.data as number;
+        }),
       );
   }
 
   syncSource(sourceId: string): Observable<any> {
-    return this._httpClient.post<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/source/${sourceId}/sync`, {})
+    return this._httpClient
+      .post<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/source/${sourceId}/sync`,
+        {},
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data
-        })
+          return response.data;
+        }),
       );
   }
 
-  getResources(sourceResourceType?: string, sourceID?: string, sourceResourceID?: string, page?: number): Observable<ResourceFhir[]> {
-    let queryParams = {}
-    if(sourceResourceType){
-      queryParams["sourceResourceType"] = sourceResourceType
+  getResources(
+    sourceResourceType?: string,
+    sourceID?: string,
+    sourceResourceID?: string,
+    page?: number,
+  ): Observable<ResourceFhir[]> {
+    let queryParams = {};
+    if (sourceResourceType) {
+      queryParams['sourceResourceType'] = sourceResourceType;
     }
-    if(sourceID){
-      queryParams["sourceID"] = sourceID
-    }
-
-    if(sourceResourceID){
-      queryParams["sourceResourceID"] = sourceResourceID
-    }
-    if(page !== undefined){
-      queryParams["page"] = page
+    if (sourceID) {
+      queryParams['sourceID'] = sourceID;
     }
 
-    return this._httpClient.get<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/fhir`, {params: queryParams})
+    if (sourceResourceID) {
+      queryParams['sourceResourceID'] = sourceResourceID;
+    }
+    if (page !== undefined) {
+      queryParams['page'] = page;
+    }
+
+    return this._httpClient
+      .get<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/fhir`,
+        { params: queryParams },
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data as ResourceFhir[]
-        })
+          return response.data as ResourceFhir[];
+        }),
       );
   }
 
@@ -260,14 +331,14 @@ export class FastenApiService {
     // Construct the full URL by embedding the practitionerId directly into the path
     const endpointUrl = `${GetEndpointAbsolutePath(
       globalThis.location,
-      environment.fasten_api_endpoint_base
+      environment.fasten_api_endpoint_base,
     )}/secure/practitioners/${practitionerId}/history`;
 
     return this._httpClient.get<ResponseWrapper>(endpointUrl).pipe(
       map((response: any) => {
         // Extract the data array from the response, just like in your example
         return response.relatedResources as ResourceFhir[];
-      })
+      }),
     );
   }
 
@@ -275,441 +346,560 @@ export class FastenApiService {
   // we should also add a way to invalidate the cache when a source is synced
   //this function is special, as it returns the raw response, for processing in the DashboardWidgetComponent
   queryResources(query?: DashboardWidgetQuery): Observable<ResponseWrapper> {
-
-
-    return this._httpClient.post<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/query`, query)
+    return this._httpClient.post<any>(
+      `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/query`,
+      query,
+    );
   }
 
   // requires:
   // - source_id: string
   // - source_resource_type: string
   // - source_resource_id: string
-  getResourceGraph(graphType?: string, selectedResourceIds?: Partial<ResourceFhir>[]): Observable<ResourceGraphResponse> {
-    if(!graphType){
-      graphType = "MedicalHistory"
+  getResourceGraph(
+    graphType?: string,
+    selectedResourceIds?: Partial<ResourceFhir>[],
+  ): Observable<ResourceGraphResponse> {
+    if (!graphType) {
+      graphType = 'MedicalHistory';
     }
 
-    return this._httpClient.post<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/graph/${graphType}`, {resource_ids: selectedResourceIds})
+    return this._httpClient
+      .post<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/graph/${graphType}`,
+        { resource_ids: selectedResourceIds },
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data as ResourceGraphResponse
-        })
+          return response.data as ResourceGraphResponse;
+        }),
       );
   }
 
-  getResourceBySourceId(sourceId: string, resourceId: string): Observable<ResourceFhir> {
-
-    return this._httpClient.get<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/fhir/${sourceId}/${resourceId}`)
+  getResourceBySourceId(
+    sourceId: string,
+    resourceId: string,
+  ): Observable<ResourceFhir> {
+    return this._httpClient
+      .get<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/fhir/${sourceId}/${resourceId}`,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data as ResourceFhir
-        })
+          return response.data as ResourceFhir;
+        }),
       );
   }
 
-  deleteResourceBySourceId(sourceId: string, resourceId: string): Observable<number> {
-    return this._httpClient.delete<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/fhir/${sourceId}/${resourceId}`)
+  deleteResourceBySourceId(
+    sourceId: string,
+    resourceId: string,
+  ): Observable<number> {
+    return this._httpClient
+      .delete<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/fhir/${sourceId}/${resourceId}`,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data as number
-        })
+          return response.data as number;
+        }),
       );
   }
 
-  updateResourceBySourceId(sourceId: string, resourceId: string, resourceRaw: any): Observable<boolean> {
-    return this._httpClient.put<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/fhir/${sourceId}/${resourceId}`, {resource_raw: resourceRaw})
+  updateResourceBySourceId(
+    sourceId: string,
+    resourceId: string,
+    resourceRaw: any,
+  ): Observable<boolean> {
+    return this._httpClient
+      .put<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/fhir/${sourceId}/${resourceId}`,
+        { resource_raw: resourceRaw },
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.success
-        })
+          return response.success;
+        }),
       );
   }
 
-  updateResource(resourceType: string, resourceId: string, payload: UpdateResourcePayload) : Observable<ResponseWrapper> {
-    return this._httpClient.patch<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/fhir/${resourceType}/${resourceId}`, payload)
+  updateResource(
+    resourceType: string,
+    resourceId: string,
+    payload: UpdateResourcePayload,
+  ): Observable<ResponseWrapper> {
+    return this._httpClient
+      .patch<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/fhir/${resourceType}/${resourceId}`,
+        payload,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response
-        })
+          return response;
+        }),
       );
   }
 
   addDashboardLocation(location: string): Observable<ResponseWrapper> {
-    return this._httpClient.post<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/dashboards`, {
-      "location": location
-    })
+    return this._httpClient
+      .post<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/dashboards`,
+        {
+          location: location,
+        },
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response
-        })
+          return response;
+        }),
       );
   }
 
   //this method allows a user to manually group related FHIR resources together (conditions, encounters, etc).
   // @deprecated - replaced by Create Manual Record Wizard
-  createResourceComposition(title: string, resources: ResourceFhir[]){
-    return this._httpClient.post<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/composition`, {
-      "resources": resources,
-      "title": title,
-    })
+  createResourceComposition(title: string, resources: ResourceFhir[]) {
+    return this._httpClient
+      .post<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/composition`,
+        {
+          resources: resources,
+          title: title,
+        },
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data
-        })
+          return response.data;
+        }),
       );
   }
 
-  getBinaryModel(sourceId: string, attachmentModel: AttachmentModel): Observable<BinaryModel> {
-    if(attachmentModel.url && !attachmentModel.data){
+  getBinaryModel(
+    sourceId: string,
+    attachmentModel: AttachmentModel,
+  ): Observable<BinaryModel> {
+    if (attachmentModel.url && !attachmentModel.data) {
       //this attachment model is a refernce to a Binary model, we need to download it first.
-      let urnPrefix = "urn:uuid:";
-      let resourceType = "Binary"
-      let resourceId = ""
-      let binaryUrl = attachmentModel.url
+      let urnPrefix = 'urn:uuid:';
+      let resourceType = 'Binary';
+      let resourceId = '';
+      let binaryUrl = attachmentModel.url;
       //strip out the urn prefix (if this is an embedded id, eg. urn:uuid:2a35e080-c5f7-4dde-b0cf-8210505708f1)
       if (binaryUrl.startsWith(urnPrefix)) {
         // PREFIX is exactly at the beginning
         resourceId = binaryUrl.slice(urnPrefix.length);
-      } else if(binaryUrl.startsWith("http://") || binaryUrl.startsWith("https://") || binaryUrl.startsWith("Binary/")){
+      } else if (
+        binaryUrl.startsWith('http://') ||
+        binaryUrl.startsWith('https://') ||
+        binaryUrl.startsWith('Binary/')
+      ) {
         //this is an absolute URL (which could be a FHIR url with Binary/xxx-xxx-xxx-xxx or a direct link to a file)
-        let urlParts = binaryUrl.split("Binary/");
-        if(urlParts.length > 1){
+        let urlParts = binaryUrl.split('Binary/');
+        if (urlParts.length > 1) {
           //this url has a Binary/xxx-xxx-xxx-xxx part, so we can use that as the resource id
           resourceId = urlParts[urlParts.length - 1];
         } else {
           //this is a fully qualified url. we need to base64 encode the url and use that as the resource id
-          resourceId = btoa(binaryUrl)
+          resourceId = btoa(binaryUrl);
         }
       }
       return this.getResourceBySourceId(sourceId, resourceId).pipe(
         map((resourceFhir: ResourceFhir) => {
-          return new BinaryModel(resourceFhir.resource_raw)
-        })
-      )
+          return new BinaryModel(resourceFhir.resource_raw);
+        }),
+      );
     } else {
       return of(new BinaryModel(attachmentModel));
     }
   }
 
-
-  getBackgroundJobs(jobType?: string, status?: string,  page?: number): Observable<BackgroundJob[]> {
-    let queryParams = {}
-    if(jobType){
-      queryParams["jobType"] = jobType
+  getBackgroundJobs(
+    jobType?: string,
+    status?: string,
+    page?: number,
+  ): Observable<BackgroundJob[]> {
+    let queryParams = {};
+    if (jobType) {
+      queryParams['jobType'] = jobType;
     }
-    if(status){
-      queryParams["status"] = status
+    if (status) {
+      queryParams['status'] = status;
     }
 
-    if(page !== undefined){
-      queryParams["page"] = page
+    if (page !== undefined) {
+      queryParams['page'] = page;
     }
 
-    return this._httpClient.get<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/jobs`, {params: queryParams})
+    return this._httpClient
+      .get<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/jobs`,
+        { params: queryParams },
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data as BackgroundJob[]
-        })
+          return response.data as BackgroundJob[];
+        }),
       );
   }
 
   //this method will persist client side errors in the database for later review & easier debugging. Primarily used for source/provider connection errors
-  createBackgroundJobError(errorData: BackgroundJobSyncData){
-    return this._httpClient.post<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/jobs/error`, errorData)
+  createBackgroundJobError(errorData: BackgroundJobSyncData) {
+    return this._httpClient
+      .post<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/jobs/error`,
+        errorData,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data
-        })
+          return response.data;
+        }),
       );
   }
 
-
   supportRequest(request: SupportRequest): Observable<any> {
-    return this._httpClient.post<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/support/request`, request)
+    return this._httpClient
+      .post<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/support/request`,
+        request,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
           // @ts-ignore
-          return {}
-        })
+          return {};
+        }),
       );
   }
 
   requestHealthSystem(requestHealth: FormRequestHealthSystem): Observable<any> {
-    return this._httpClient.post<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/support/healthsystem`, requestHealth)
+    return this._httpClient
+      .post<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/support/healthsystem`,
+        requestHealth,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
           // @ts-ignore
-          return {}
-        })
+          return {};
+        }),
       );
   }
 
   getAllUsers(): Observable<User[]> {
-    return this._httpClient.get<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/users`)
+    return this._httpClient
+      .get<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/users`,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response.data as User[]
-        })
+          return response.data as User[];
+        }),
       );
   }
 
   getIPSExport(exportType?: string) {
-    let format = exportType || "pdf"
-    let contentType = "application/pdf"
-    if (exportType == "html") {
-      contentType = "text/html"
+    let format = exportType || 'pdf';
+    let contentType = 'application/pdf';
+    if (exportType == 'html') {
+      contentType = 'text/html';
     }
 
     let httpHeaders = new HttpHeaders().set('Accept', contentType);
     let queryParams = {
-      "format": format
+      format: format,
     };
 
-    console.log("requesting", `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/summary/ips`);
+    console.log(
+      'requesting',
+      `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/summary/ips`,
+    );
 
-    this._httpClient.get(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/summary/ips`, {
-      params: queryParams,
-      headers: httpHeaders,
-      responseType: 'blob' // Request the data as a Blob
-    }).subscribe((data: Blob) => {
-      console.log(data)
-      // Create a URL for the blob
-      const fileURL = URL.createObjectURL(data);
+    this._httpClient
+      .get(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/summary/ips`,
+        {
+          params: queryParams,
+          headers: httpHeaders,
+          responseType: 'blob', // Request the data as a Blob
+        },
+      )
+      .subscribe((data: Blob) => {
+        console.log(data);
+        // Create a URL for the blob
+        const fileURL = URL.createObjectURL(data);
 
-      // Create a temporary anchor element and trigger the download
-      const link = document.createElement('a');
-      link.href = fileURL;
-      link.setAttribute('download', `ips_summary.${exportType}`); // Set the filename for the download
-      document.body.appendChild(link);
-      link.click();
+        // Create a temporary anchor element and trigger the download
+        const link = document.createElement('a');
+        link.href = fileURL;
+        link.setAttribute('download', `ips_summary.${exportType}`); // Set the filename for the download
+        document.body.appendChild(link);
+        link.click();
 
-      // Clean up by removing the link and revoking the URL
-      document.body.removeChild(link);
-      URL.revokeObjectURL(fileURL);
-    });
+        // Clean up by removing the link and revoking the URL
+        document.body.removeChild(link);
+        URL.revokeObjectURL(fileURL);
+      });
   }
 
   getAllPractitioners(): Observable<Practitioner[]> {
     const endpointUrl = `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/fhir?sourceResourceType=Practitioner`;
-    return this._httpClient.get<any>(endpointUrl)
-      .pipe(
-        map((response: ResponseWrapper) => {
-          const practitioners = response.data.map(item => {
-            let email: string | undefined;
-            let emailUse: string | undefined;
-            let phone: string | undefined;
-            let phoneUse: string | undefined;
-            let fax: string | undefined;
-            let faxUse: string | undefined;
-            let primaryTelecom: any;
-  
-            if (item.resource_raw.telecom && Array.isArray(item.resource_raw.telecom)) {
-              item.resource_raw.telecom.forEach((telecom: any) => {
-                switch (telecom.system) {
-                  case 'email':
-                    if (!email) { 
-                      email = telecom.value?.toLowerCase();
-                      emailUse = telecom.use || 'work';
-                    }
-                    break;
-                  case 'phone':
-                    if (!phone) {
-                      phone = telecom.value;
-                      phoneUse = telecom.use || 'work';
-                    }
-                    break;
-                  case 'fax':
-                    if (!fax) { 
-                      fax = telecom.value;
-                      faxUse = telecom.use || 'work'; 
-                    }
-                    break;
-                }
-              });
-              primaryTelecom = item.resource_raw.telecom[0];
-            } else if (item.resource_raw.telecom) {
-              primaryTelecom = item.resource_raw.telecom;
-              switch (primaryTelecom.system) {
+    return this._httpClient.get<any>(endpointUrl).pipe(
+      map((response: ResponseWrapper) => {
+        const practitioners = response.data.map((item) => {
+          let email: string | undefined;
+          let emailUse: string | undefined;
+          let phone: string | undefined;
+          let phoneUse: string | undefined;
+          let fax: string | undefined;
+          let faxUse: string | undefined;
+          let primaryTelecom: any;
+
+          if (
+            item.resource_raw.telecom &&
+            Array.isArray(item.resource_raw.telecom)
+          ) {
+            item.resource_raw.telecom.forEach((telecom: any) => {
+              switch (telecom.system) {
                 case 'email':
-                  email = primaryTelecom.value?.toLowerCase();
-                  emailUse = primaryTelecom.use || 'work';
+                  if (!email) {
+                    email = telecom.value?.toLowerCase();
+                    emailUse = telecom.use || 'work';
+                  }
                   break;
                 case 'phone':
-                  phone = primaryTelecom.value;
-                  phoneUse = primaryTelecom.use || 'work';
+                  if (!phone) {
+                    phone = telecom.value;
+                    phoneUse = telecom.use || 'work';
+                  }
                   break;
                 case 'fax':
-                  fax = primaryTelecom.value;
-                  faxUse = primaryTelecom.use || 'work';
+                  if (!fax) {
+                    fax = telecom.value;
+                    faxUse = telecom.use || 'work';
+                  }
                   break;
               }
+            });
+            primaryTelecom = item.resource_raw.telecom[0];
+          } else if (item.resource_raw.telecom) {
+            primaryTelecom = item.resource_raw.telecom;
+            switch (primaryTelecom.system) {
+              case 'email':
+                email = primaryTelecom.value?.toLowerCase();
+                emailUse = primaryTelecom.use || 'work';
+                break;
+              case 'phone':
+                phone = primaryTelecom.value;
+                phoneUse = primaryTelecom.use || 'work';
+                break;
+              case 'fax':
+                fax = primaryTelecom.value;
+                faxUse = primaryTelecom.use || 'work';
+                break;
             }
-  
-            let jobTitle: string | undefined;
-            let organization: string | undefined;
-  
-            if (item.resource_raw.qualification && Array.isArray(item.resource_raw.qualification)) {
-              const firstQualification = item.resource_raw.qualification[0];
-              if (firstQualification?.code?.coding) {
-                const coding = firstQualification.code.coding[0];
-                jobTitle = coding?.display || coding?.code;
-              } else if (firstQualification?.code?.text) {
-                jobTitle = firstQualification.code.text;
-              }
+          }
 
-              if (firstQualification?.issuer?.display) {
-                organization = firstQualification.issuer.display;
-              } else if (firstQualification?.issuer?.reference) {
-                organization = firstQualification.issuer.reference.replace('Organization/', '');
-              }
+          let jobTitle: string | undefined;
+          let organization: string | undefined;
+
+          if (
+            item.resource_raw.qualification &&
+            Array.isArray(item.resource_raw.qualification)
+          ) {
+            const firstQualification = item.resource_raw.qualification[0];
+            if (firstQualification?.code?.coding) {
+              const coding = firstQualification.code.coding[0];
+              jobTitle = coding?.display || coding?.code;
+            } else if (firstQualification?.code?.text) {
+              jobTitle = firstQualification.code.text;
             }
-  
-            if (!jobTitle && item.resource_raw.practitionerRole) {
-              if (Array.isArray(item.resource_raw.practitionerRole)) {
-                const role = item.resource_raw.practitionerRole[0];
-                if (role?.code) {
-                  jobTitle = role.code.coding?.[0]?.display || role.code.text;
-                }
-                if (role?.organization?.display) {
-                  organization = role.organization.display;
-                }
-              }
-            }
-  
-            if (!jobTitle && item.resource_raw.extension) {
-              const specialtyExtension = item.resource_raw.extension.find((ext: any) => 
-                ext.url?.includes('specialty') || ext.url?.includes('job') || ext.url?.includes('title')
+
+            if (firstQualification?.issuer?.display) {
+              organization = firstQualification.issuer.display;
+            } else if (firstQualification?.issuer?.reference) {
+              organization = firstQualification.issuer.reference.replace(
+                'Organization/',
+                '',
               );
-              if (specialtyExtension?.valueString) {
-                jobTitle = specialtyExtension.valueString;
-              } else if (specialtyExtension?.valueCoding?.display) {
-                jobTitle = specialtyExtension.valueCoding.display;
+            }
+          }
+
+          if (!jobTitle && item.resource_raw.practitionerRole) {
+            if (Array.isArray(item.resource_raw.practitionerRole)) {
+              const role = item.resource_raw.practitionerRole[0];
+              if (role?.code) {
+                jobTitle = role.code.coding?.[0]?.display || role.code.text;
+              }
+              if (role?.organization?.display) {
+                organization = role.organization.display;
               }
             }
-  
-            const practitioner: Practitioner = {
-              source_resource_id: item.source_resource_id,
-              source_id: item.source_id,
-              source_resource_type: item.source_resource_type,
-              full_name: item.resource_raw.name?.[0]?.text || item?.sort_title || 'N/A',
-              address: item.resource_raw.address?.[0] || {
-                line: [], 
-                city: '', 
-                state: '', 
-                postalCode: '', 
-                country: ''
-              },
-              email: email,
-              emailUse: emailUse,
-              phone: phone,
-              phoneUse: phoneUse,
-              fax: fax,
-              faxUse: faxUse,
-              
-              jobTitle: jobTitle,
-              organization: organization,
-              qualification: item.resource_raw.qualification,
-              
-              telecom: primaryTelecom || {
-                system: '', 
-                value: '', 
-                use: ''
-              },
-              
-              formattedAddress: '',
-              formattedTelecom: '',
+          }
 
-              resource_raw: item.resource_raw
-            };
-  
-            return practitioner;
-          });
-          
-          console.log('Fetched practitioners with job title, organization, and contact use properties:', practitioners);
-          return practitioners as Practitioner[];
-        })
-      );
+          if (!jobTitle && item.resource_raw.extension) {
+            const specialtyExtension = item.resource_raw.extension.find(
+              (ext: any) =>
+                ext.url?.includes('specialty') ||
+                ext.url?.includes('job') ||
+                ext.url?.includes('title'),
+            );
+            if (specialtyExtension?.valueString) {
+              jobTitle = specialtyExtension.valueString;
+            } else if (specialtyExtension?.valueCoding?.display) {
+              jobTitle = specialtyExtension.valueCoding.display;
+            }
+          }
+
+          const practitioner: Practitioner = {
+            source_resource_id: item.source_resource_id,
+            source_id: item.source_id,
+            source_resource_type: item.source_resource_type,
+            full_name:
+              item.resource_raw.name?.[0]?.text || item?.sort_title || 'N/A',
+            address: item.resource_raw.address?.[0] || {
+              line: [],
+              city: '',
+              state: '',
+              postalCode: '',
+              country: '',
+            },
+            email: email,
+            emailUse: emailUse,
+            phone: phone,
+            phoneUse: phoneUse,
+            fax: fax,
+            faxUse: faxUse,
+
+            jobTitle: jobTitle,
+            organization: organization,
+            qualification: item.resource_raw.qualification,
+
+            telecom: primaryTelecom || {
+              system: '',
+              value: '',
+              use: '',
+            },
+
+            formattedAddress: '',
+            formattedTelecom: '',
+
+            resource_raw: item.resource_raw,
+          };
+
+          return practitioner;
+        });
+
+        console.log(
+          'Fetched practitioners with job title, organization, and contact use properties:',
+          practitioners,
+        );
+        return practitioners as Practitioner[];
+      }),
+    );
   }
 
-  deleteResourceFhir(resourceType: string, resourceId: string): Observable<any> {
-    return this._httpClient.delete<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/fhir-by-type/${resourceType}/${resourceId}`)
+  deleteResourceFhir(
+    resourceType: string,
+    resourceId: string,
+  ): Observable<any> {
+    return this._httpClient
+      .delete<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/fhir-by-type/${resourceType}/${resourceId}`,
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response
-        })
+          return response;
+        }),
       );
   }
-  
+
   deletePractitioner(practitionerId: string): Observable<any> {
     return this.deleteResourceFhir('Practitioner', practitionerId);
   }
 
   createPractitioner(practitionerResource: any): Observable<any> {
-    return this._httpClient.post<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/practitioners`, {
-      resource: practitionerResource
-    })
+    return this._httpClient
+      .post<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/practitioners`,
+        {
+          resource: practitionerResource,
+        },
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response
-        })
+          return response;
+        }),
       );
   }
 
-  updatePractitioner(practitionerId: string, practitionerResource: any): Observable<any> {
-    return this._httpClient.put<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/practitioners/${practitionerId}`, {
-      resource: practitionerResource
-    })
+  updatePractitioner(
+    practitionerId: string,
+    practitionerResource: any,
+  ): Observable<any> {
+    return this._httpClient
+      .put<any>(
+        `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/practitioners/${practitionerId}`,
+        {
+          resource: practitionerResource,
+        },
+      )
       .pipe(
         map((response: ResponseWrapper) => {
-          return response
-        })
+          return response;
+        }),
       );
   }
 
-  addFavorite(resourceType: string, resourceId: string, sourceId: string): Observable<any> {
+  addFavorite(
+    resourceType: string,
+    resourceId: string,
+    sourceId: string,
+  ): Observable<any> {
     const endpointUrl = `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/user/favorites`;
-    return this._httpClient.post<any>(endpointUrl, {
-      resource_type: resourceType,
-      resource_id: resourceId,
-      source_id: sourceId
-    })
-    .pipe(
-      map((response: ResponseWrapper) => {
-        return response
-      })
-    );
-  }
-
-  removeFavorite(resourceType: string, resourceId: string, sourceId: string): Observable<any> {
-    const endpointUrl = `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/user/favorites`;
-    return this._httpClient.delete<any>(endpointUrl, {
-      body: {
+    return this._httpClient
+      .post<any>(endpointUrl, {
         resource_type: resourceType,
         resource_id: resourceId,
-        source_id: sourceId
-      }
-    })
-    .pipe(
-      map((response: ResponseWrapper) => {
-        return response
+        source_id: sourceId,
       })
-    );
+      .pipe(
+        map((response: ResponseWrapper) => {
+          return response;
+        }),
+      );
+  }
+
+  removeFavorite(
+    resourceType: string,
+    resourceId: string,
+    sourceId: string,
+  ): Observable<any> {
+    const endpointUrl = `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/user/favorites`;
+    return this._httpClient
+      .delete<any>(endpointUrl, {
+        body: {
+          resource_type: resourceType,
+          resource_id: resourceId,
+          source_id: sourceId,
+        },
+      })
+      .pipe(
+        map((response: ResponseWrapper) => {
+          return response;
+        }),
+      );
   }
 
   getUserFavorites(resourceType?: string): Observable<Favorite[]> {
     let endpointUrl = `${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/user/favorites`;
     let queryParams = {};
-    
+
     if (resourceType) {
       queryParams['resource_type'] = resourceType;
     }
-    
-    return this._httpClient.get<any>(endpointUrl, { params: queryParams })
-      .pipe(
-        map((response: ResponseWrapper) => {
-          return response.data;
-        })
-      );
-    
+
+    return this._httpClient.get<any>(endpointUrl, { params: queryParams }).pipe(
+      map((response: ResponseWrapper) => {
+        return response.data;
+      }),
+    );
   }
 }

--- a/frontend/src/app/services/fasten-api.service.ts
+++ b/frontend/src/app/services/fasten-api.service.ts
@@ -29,6 +29,7 @@ import {
   List
 } from 'fhir/r4';
 import {FormRequestHealthSystem} from '../models/fasten/form-request-health-system';
+import { UpdateResourcePayload } from '../models/fasten/resource_update';
 import { Favorite } from '../pages/practitioner-list/practitioner-list.component';
 
 @Injectable({
@@ -320,6 +321,15 @@ export class FastenApiService {
       .pipe(
         map((response: ResponseWrapper) => {
           return response.success
+        })
+      );
+  }
+
+  updateResource(resourceType: string, resourceId: string, payload: UpdateResourcePayload) : Observable<ResponseWrapper> {
+    return this._httpClient.patch<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/fhir/${resourceType}/${resourceId}`, payload)
+      .pipe(
+        map((response: ResponseWrapper) => {
+          return response
         })
       );
   }
@@ -622,7 +632,7 @@ export class FastenApiService {
   }
 
   deleteResourceFhir(resourceType: string, resourceId: string): Observable<any> {
-    return this._httpClient.delete<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/fhir/${resourceType}/${resourceId}`)
+    return this._httpClient.delete<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/fhir-by-type/${resourceType}/${resourceId}`)
       .pipe(
         map((response: ResponseWrapper) => {
           return response

--- a/frontend/src/app/services/fasten-api.service.ts
+++ b/frontend/src/app/services/fasten-api.service.ts
@@ -29,7 +29,6 @@ import {
   List
 } from 'fhir/r4';
 import {FormRequestHealthSystem} from '../models/fasten/form-request-health-system';
-import { UpdateResourcePayload } from '../models/fasten/resource_update';
 import { Favorite } from '../pages/practitioner-list/practitioner-list.component';
 
 @Injectable({
@@ -307,11 +306,20 @@ export class FastenApiService {
       );
   }
 
-  updateResource(resourceType: string, resourceId: string, payload: UpdateResourcePayload) : Observable<ResponseWrapper> {
-    return this._httpClient.patch<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/fhir/${resourceType}/${resourceId}`, payload)
+  deleteResourceBySourceId(sourceId: string, resourceId: string): Observable<number> {
+    return this._httpClient.delete<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/fhir/${sourceId}/${resourceId}`)
       .pipe(
         map((response: ResponseWrapper) => {
-          return response
+          return response.data as number
+        })
+      );
+  }
+
+  updateResourceBySourceId(sourceId: string, resourceId: string, resourceRaw: any): Observable<boolean> {
+    return this._httpClient.put<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/resource/fhir/${sourceId}/${resourceId}`, {resource_raw: resourceRaw})
+      .pipe(
+        map((response: ResponseWrapper) => {
+          return response.success
         })
       );
   }


### PR DESCRIPTION
### Purpose

Allow users to edit and delete FHIR resources directly from the resource detail page for manually-created records.

### Tickets

- Closes #631 

### Summary of Changes

- Add DELETE and PUT endpoints for per-resource edit/delete, restricted to manual/fasten sources
- Add delete button with confirmation modal on the resource detail page
- Add edit modal with type-specific form fields for 7 FHIR resource types
- Add backward-compatible PATCH and DELETE-by-type endpoints for the medical record wizard
- Add backend and frontend unit tests

### Screenshots / Recordings

<img width="700" src="https://github.com/user-attachments/assets/0cde2d79-f41b-40d3-b5b3-d5b18fe4d19c" />

https://github.com/user-attachments/assets/b5fc85f0-8107-40c0-a5e5-3a6d70570cab