### PR TITLE
Disallow reserved usernames during user registration

### DIFF
--- a/backend/pkg/database/gorm_common.go
+++ b/backend/pkg/database/gorm_common.go
@@ -46,15 +46,17 @@ func (gr *GormRepository) CreateUser(ctx context.Context, user *models.User) err
 	if err := user.HashPassword(user.Password); err != nil {
 		return err
 	}
+
+	// SECURITY: disallow reserved usernames that could be used for phishing or
+	// confusion attacks (e.g., "admin", "support", "system").
+	if isReservedUsername(user.Username) {
+		return fmt.Errorf("username '%s' is reserved and cannot be used", user.Username)
+	}
+
 	record := gr.GormClient.Create(user)
 	if record.Error != nil {
 		return record.Error
 	}
-
-	//SECURITY:
-	//TODO: we should disallow reserved usernames:
-	// https://github.com/forwardemail/reserved-email-addresses-list/blob/master/admin-list.json
-	// https://github.com/shouldbee/reserved-usernames/blob/master/reserved-usernames.txt
 
 	//create user settings
 	err := gr.PopulateDefaultUserSettings(ctx, user.ID)
@@ -1573,4 +1575,36 @@ func (gr *GormRepository) DeleteResourceByTypeAndId(ctx context.Context, sourceR
 
 	fmt.Printf("Successfully deleted resource: %s from table: %s\n", sourceResourceId, tableName)
 	return nil
+}
+
+// reservedUsernames is a curated list of usernames that should not be allowed
+// for user registration. These could be used for phishing, social engineering,
+// or confusion attacks if a user were to register with them.
+// References:
+// - https://github.com/forwardemail/reserved-email-addresses-list/blob/master/admin-list.json
+// - https://github.com/shouldbee/reserved-usernames/blob/master/reserved-usernames.txt
+var reservedUsernames = map[string]bool{
+	"admin":        true,
+	"administrator": true,
+	"api":          true,
+	"contact":      true,
+	"fasten":       true,
+	"help":         true,
+	"info":         true,
+	"login":        true,
+	"mail":         true,
+	"noreply":      true,
+	"postmaster":   true,
+	"root":         true,
+	"security":     true,
+	"support":      true,
+	"system":       true,
+	"webmaster":    true,
+	"www":          true,
+}
+
+// isReservedUsername checks if the given username is in the reserved list.
+// The check is case-insensitive.
+func isReservedUsername(username string) bool {
+	return reservedUsernames[strings.ToLower(strings.TrimSpace(username))]
 }


### PR DESCRIPTION
## Summary

Adds validation to reject reserved usernames (admin, support, system, root, etc.) 
during user creation, preventing potential phishing or social engineering attacks.

## Problem

The `CreateUser` function had a SECURITY TODO noting that reserved usernames should 
be disallowed. Without this check, a user could register as "admin" or "support" and 
potentially confuse other users in a multi-user deployment.

## Solution

- Added `isReservedUsername()` helper with a curated, case-insensitive list
- Validation runs before the database insert (fail fast)
- Returns a clear error message: `"username 'X' is reserved and cannot be used"`
- List includes: admin, administrator, api, contact, fasten, help, info, login, 
  mail, noreply, postmaster, root, security, support, system, webmaster, www

## References

Per the TODO comments:
- https://github.com/forwardemail/reserved-email-addresses-list/blob/master/admin-list.json
- https://github.com/shouldbee/reserved-usernames/blob/master/reserved-usernames.txt

## Type of change

- [x] Security improvement
